### PR TITLE
fix: parse commits with indented body

### DIFF
--- a/lib/git-log.js
+++ b/lib/git-log.js
@@ -41,6 +41,25 @@ exports.GIT_LOG_YAML_PRETTY_FORMAT = [
   '- subject: >-',
   '    %s',
   '  body: |-',
+
+  // This is a hack to force the YAML parser
+  // to parse indented body strings.
+  // If we have a commit whose body is indented, like:
+  //
+  //   My commit
+  //
+  //    Lorem ipsum
+  //
+  //   Foo bar
+  //
+  // YAML will (rightfully) complain that the body is
+  // not indented correctly.
+  //
+  // As a workaround, we pass a static string on the
+  // correct indentation as the first line of the body
+  // and then omit it in the parser.
+  '    XXX',
+
   '    %w(0,0,4)%b'
 ].join('%n');
 
@@ -175,6 +194,13 @@ exports.parseGitLogYAMLOutput = (output, options = {}) => {
     if (_.isUndefined(commit.body)) {
       throw new Error('Invalid commit: no body');
     }
+
+    // Omit the first line in the body
+    commit.body = _.chain(commit.body)
+      .split('\n')
+      .tail()
+      .join('\n')
+      .value();
 
     if (!options.parseFooterTags) {
       return {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "eslint": "^3.0.0",
+    "indent-string": "^3.0.0",
     "mocha": "^2.5.3",
     "mochainon": "^1.0.0"
   },

--- a/tests/git-log.spec.js
+++ b/tests/git-log.spec.js
@@ -439,6 +439,63 @@ describe('GitLog', function() {
       ]);
     });
 
+    it('should parse a commit with an initial single space indented body', function() {
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          ' Currently we had AppImage scripts and other resources in various',
+          ' different places in the code base.',
+          '',
+          'Foo: bar',
+          'Bar: baz'
+        ].join('\n')
+      }));
+
+      m.chai.expect(result).to.deep.equal([
+        {
+          subject: 'refactor: group AppImage related stuff (#498)',
+          body: [
+            ' Currently we had AppImage scripts and other resources in various',
+            ' different places in the code base.',
+            ''
+          ].join('\n'),
+          footer: {
+            Foo: 'bar',
+            Bar: 'baz'
+          }
+        }
+      ]);
+    });
+
+    it('should parse a commit with an initial multiple space indented body', function() {
+
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          '    Currently we had AppImage scripts and other resources in various',
+          '    different places in the code base.',
+          '',
+          'Foo: bar',
+          'Bar: baz'
+        ].join('\n')
+      }));
+
+      m.chai.expect(result).to.deep.equal([
+        {
+          subject: 'refactor: group AppImage related stuff (#498)',
+          body: [
+            '    Currently we had AppImage scripts and other resources in various',
+            '    different places in the code base.',
+            ''
+          ].join('\n'),
+          footer: {
+            Foo: 'bar',
+            Bar: 'baz'
+          }
+        }
+      ]);
+    });
+
   });
 
 });

--- a/tests/git-log.spec.js
+++ b/tests/git-log.spec.js
@@ -18,6 +18,7 @@
 
 const m = require('mochainon');
 const gitLog = require('../lib/git-log');
+const utils = require('./utils');
 
 describe('GitLog', function() {
 
@@ -162,13 +163,13 @@ describe('GitLog', function() {
   describe('.parseGitLogYAMLOutput()', function() {
 
     it('should parse the output as it is if no hooks', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Currently we had AppImage scripts and other resources in various',
-        '    different places in the code base.'
-      ].join('\n'));
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Currently we had AppImage scripts and other resources in various',
+          'different places in the code base.'
+        ].join('\n')
+      }));
 
       m.chai.expect(result).to.deep.equal([
         {
@@ -202,13 +203,13 @@ describe('GitLog', function() {
     });
 
     it('should support a subjectParser hook', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Currently we had AppImage scripts and other resources in various',
-        '    different places in the code base.'
-      ].join('\n'), {
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Currently we had AppImage scripts and other resources in various',
+          'different places in the code base.'
+        ].join('\n')
+      }), {
         subjectParser: (subject) => {
           return subject.toUpperCase();
         }
@@ -227,15 +228,15 @@ describe('GitLog', function() {
     });
 
     it('should support a bodyParser hook', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Currently we had AppImage scripts and other resources in various',
-        '    different places in the code base.'
-      ].join('\n'), {
-        bodyParser: (body) => {
-          return body.toUpperCase();
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Currently we had AppImage scripts and other resources in various',
+          'different places in the code base.'
+        ].join('\n')
+      }), {
+        bodyParser: (subject) => {
+          return subject.toUpperCase();
         }
       });
 
@@ -252,16 +253,16 @@ describe('GitLog', function() {
     });
 
     it('should parse footer tags by default', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Currently we had AppImage scripts and other resources in various',
-        '    different places in the code base.',
-        '',
-        '    Foo: bar',
-        '    Bar: baz'
-      ].join('\n'));
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Currently we had AppImage scripts and other resources in various',
+          'different places in the code base.',
+          '',
+          'Foo: bar',
+          'Bar: baz'
+        ].join('\n')
+      }));
 
       m.chai.expect(result).to.deep.equal([
         {
@@ -280,16 +281,16 @@ describe('GitLog', function() {
     });
 
     it('should not parse footer tags if parseFooterTags is false', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Currently we had AppImage scripts and other resources in various',
-        '    different places in the code base.',
-        '',
-        '    Foo: bar',
-        '    Bar: baz'
-      ].join('\n'), {
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Currently we had AppImage scripts and other resources in various',
+          'different places in the code base.',
+          '',
+          'Foo: bar',
+          'Bar: baz'
+        ].join('\n')
+      }), {
         parseFooterTags: false
       });
 
@@ -308,13 +309,13 @@ describe('GitLog', function() {
     });
 
     it('should parse footer tags when no body', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Foo: bar',
-        '    Bar: baz'
-      ].join('\n'));
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Foo: bar',
+          'Bar: baz'
+        ].join('\n')
+      }));
 
       m.chai.expect(result).to.deep.equal([
         {
@@ -329,14 +330,14 @@ describe('GitLog', function() {
     });
 
     it('should parse footer tags with hyphens', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Hello-World: bar',
-        '    -hey-: there',
-        '    Bar--Foo: baz'
-      ].join('\n'));
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Hello-World: bar',
+          '-hey-: there',
+          'Bar--Foo: baz'
+        ].join('\n')
+      }));
 
       m.chai.expect(result).to.deep.equal([
         {
@@ -352,18 +353,18 @@ describe('GitLog', function() {
     });
 
     it('should stop parsing footer tags after a new line', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Currently we had AppImage scripts and other resources in various',
-        '    different places in the code base.',
-        '',
-        '    Foo: bar',
-        '    Bar: baz',
-        '',
-        '    Baz: qux'
-      ].join('\n'));
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Currently we had AppImage scripts and other resources in various',
+          'different places in the code base.',
+          '',
+          'Foo: bar',
+          'Bar: baz',
+          '',
+          'Baz: qux'
+        ].join('\n')
+      }));
 
       m.chai.expect(result).to.deep.equal([
         {
@@ -384,17 +385,17 @@ describe('GitLog', function() {
     });
 
     it('should stop parsing footer tags after a non tag line', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Currently we had AppImage scripts and other resources in various',
-        '    different places in the code base.',
-        '',
-        '    Foo: bar',
-        '    Hello World',
-        '    Baz: qux'
-      ].join('\n'));
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Currently we had AppImage scripts and other resources in various',
+          'different places in the code base.',
+          '',
+          'Foo: bar',
+          'Hello World',
+          'Baz: qux'
+        ].join('\n')
+      }));
 
       m.chai.expect(result).to.deep.equal([
         {
@@ -414,15 +415,15 @@ describe('GitLog', function() {
     });
 
     it('should parse footer tags with weird colon spacings', function() {
-      const result = gitLog.parseGitLogYAMLOutput([
-        '- subject: >-',
-        '    refactor: group AppImage related stuff (#498)',
-        '  body: |-',
-        '    Foo     :     bar',
-        '    Bar:baz',
-        '    Baz    :qux',
-        '    Hey:    there'
-      ].join('\n'));
+      const result = gitLog.parseGitLogYAMLOutput(utils.formatCommit({
+        subject: 'refactor: group AppImage related stuff (#498)',
+        body: [
+          'Foo     :     bar',
+          'Bar:baz',
+          'Baz    :qux',
+          'Hey:    there'
+        ].join('\n')
+      }));
 
       m.chai.expect(result).to.deep.equal([
         {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -39,6 +39,7 @@ exports.formatCommit = (options) => {
     '- subject: >-',
     `    ${options.subject}`,
     '  body: |-',
+    '    XXX',
     indentString(options.body, 4)
   ].join('\n');
 };

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const indentString = require('indent-string');
+
+/**
+ * @summary Format commit in a similar way we ask git to do it with `--pretty`
+ * @function
+ * @public
+ *
+ * @param {Object} options - options
+ * @param {String} options.subject - commit subject
+ * @param {String} options.body - commit body
+ * @returns {String} formatted commit
+ *
+ * @example
+ * const formattedCommit = utils.formatCommit({
+ *   subject: 'Do x, y, and z',
+ *   body: 'Foo\nbar'
+ * });
+ */
+exports.formatCommit = (options) => {
+  return [
+    '- subject: >-',
+    `    ${options.subject}`,
+    '  body: |-',
+    indentString(options.body, 4)
+  ].join('\n');
+};

--- a/tests/versionist.spec.js
+++ b/tests/versionist.spec.js
@@ -20,6 +20,7 @@ const m = require('mochainon');
 const _ = require('lodash');
 const childProcess = require('child_process');
 const versionist = require('../lib/versionist');
+const utils = require('./utils');
 
 describe('Versionist', function() {
 
@@ -57,13 +58,13 @@ describe('Versionist', function() {
 
       beforeEach(function() {
         this.childProcessExecStub = m.sinon.stub(childProcess, 'exec');
-        this.childProcessExecStub.yields(null, [
-          '- subject: >-',
-          '    refactor: group AppImage related stuff (#498)',
-          '  body: |-',
-          '    Currently we had AppImage scripts and other resources in various',
-          '    different places in the code base.'
-        ].join('\n'), '');
+        this.childProcessExecStub.yields(null, utils.formatCommit({
+          subject: 'refactor: group AppImage related stuff (#498)',
+          body: [
+            'Currently we had AppImage scripts and other resources in various',
+            'different places in the code base.'
+          ].join('\n')
+        }), '');
       });
 
       afterEach(function() {


### PR DESCRIPTION
There are some commits we've seen in the wild while using this module that
indent the body for some reason (a space or two spaces usually). For
example:

```
My commit

 Lorem ipsum dolor sit amet.
Hello world.

Fixes: #350
```

This confuses the YAML parser, since applying our custom `git log
--pretty` format to such commits yields:

```
- subject >-
   My commit
 body: |-
     Lorem ipsum dolor sit amet.
     Hello world.

    Fixes: #350
```

Which of course is not well indented.

We've considered moving away from YAML to another serialisation technology
that copes with these kind of multi-line string issues, however we found a
small workaround that allows us to not spend time building and maintaing
something else:

If we pass *any* dummy string as the first line of `body`, and make it well
indented, the remaining of the body will be parsed correctly. Therefore, we
tweak our parser to pass a dummy `XXX`, and implement code in the parser to
omit it.

Change-Type: patch
Changelog-Entry: Support commits with indented bodies.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>