### PR TITLE
fix: `stdout maxBuffer exceeded` when parsing big logs 

### DIFF
--- a/lib/git-log.js
+++ b/lib/git-log.js
@@ -110,36 +110,37 @@ exports.getGitLogRevisionRange = (options = {}) => {
  * @param {String} [options.startReference] - start reference
  * @param {String} [options.endReference] - end reference
  * @param {Boolean} [options.includeMergeCommits=false] - include merge commits
- * @returns {String} `git log` command
+ * @returns {String[]} log command arguments
  *
  * @throws Will throw if the `gitDirectory` option is missing.
  *
  * @example
- * const command = gitLog.getGitLogCommandThatOutputsYaml({
+ * const command = gitLog.getGitLogCommandArgumentsThatOutputYaml({
  *   gitDirectory: 'path/to/.git',
  *   startReference: 'mytag1',
  *   endReference: 'mytag2',
  *   includeMergeCommits: false
  * });
  */
-exports.getGitLogCommandThatOutputsYaml = (options = {}) => {
+exports.getGitLogCommandArgumentsThatOutputYaml = (options = {}) => {
 
   if (!options.gitDirectory) {
     throw new Error('Missing the gitDirectory option');
   }
 
   const command = [
-    'git',
     `--git-dir=${options.gitDirectory}`,
     'log',
-    `--pretty="${exports.GIT_LOG_YAML_PRETTY_FORMAT}"`
+    `--pretty=${exports.GIT_LOG_YAML_PRETTY_FORMAT}`
   ];
 
   if (!options.includeMergeCommits) {
     command.push('--no-merges');
   }
 
-  return `${command.join(' ')} ${exports.getGitLogRevisionRange(options)}`;
+  command.push(exports.getGitLogRevisionRange(options));
+
+  return command;
 };
 
 /**
@@ -159,13 +160,13 @@ exports.getGitLogCommandThatOutputsYaml = (options = {}) => {
  * @returns {Object[]} parsed commits
  *
  * @example
- * const command = gitLog.getGitLogCommandThatOutputsYaml({
+ * const command = gitLog.getGitLogCommandArgumentsThatOutputYaml({
  *   gitDirectory: 'path/to/.git',
  *   startReference: 'mytag1',
  *   endReference: 'mytag2'
  * });
  *
- * const output = childProcess.execSync(command).toString();
+ * const output = childProcess.execSync(`git ${command.join(' ')}`).toString();
  *
  * const commits = gitLog.parseGitLogYAMLOutput(output, {
  *   parseFooterTags: true,

--- a/lib/versionist.js
+++ b/lib/versionist.js
@@ -69,7 +69,7 @@ exports.readCommitHistory = (gitDirectory, options = {}, callback) => {
     throw new Error('Missing gitDirectory');
   }
 
-  const command = gitLog.getGitLogCommandThatOutputsYaml({
+  const command = gitLog.getGitLogCommandArgumentsThatOutputYaml({
     gitDirectory: gitDirectory,
     startReference: options.startReference,
     endReference: options.endReference,

--- a/lib/versionist.js
+++ b/lib/versionist.js
@@ -76,13 +76,26 @@ exports.readCommitHistory = (gitDirectory, options = {}, callback) => {
     includeMergeCommits: options.includeMergeCommits
   });
 
-  childProcess.exec(command, (error, stdout, stderr) => {
-    if (error) {
-      return callback(error);
-    }
+  const child = childProcess.spawn('git', command);
+  let stdout = '';
 
-    if (!_.isEmpty(stderr)) {
-      return callback(new Error(stderr));
+  child.stdout.on('data', (data) => {
+    stdout += data;
+  });
+
+  child.stderr.on('data', (data) => {
+    child.kill();
+    return callback(new Error(data));
+  });
+
+  child.on('error', (error) => {
+    child.kill();
+    return callback(error);
+  });
+
+  child.on('close', (code) => {
+    if (code !== 0) {
+      return callback(new Error(`Child process exitted with error code: ${code}`));
     }
 
     const parsedCommits = gitLog.parseGitLogYAMLOutput(stdout, {

--- a/tests/git-log.spec.js
+++ b/tests/git-log.spec.js
@@ -56,11 +56,11 @@ describe('GitLog', function() {
 
   });
 
-  describe('.getGitLogCommandThatOutputsYaml()', function() {
+  describe('.getGitLogCommandArgumentsThatOutputYaml()', function() {
 
     it('should throw if no gitDirectory option', function() {
       m.chai.expect(() => {
-        gitLog.getGitLogCommandThatOutputsYaml({
+        gitLog.getGitLogCommandArgumentsThatOutputYaml({
           startReference: 'foo',
           endReference: 'bar'
         });
@@ -70,18 +70,19 @@ describe('GitLog', function() {
     describe('given the includeMergeCommits = true option', function() {
 
       it('should construct the right command', function() {
-        const command = gitLog.getGitLogCommandThatOutputsYaml({
+        const command = gitLog.getGitLogCommandArgumentsThatOutputYaml({
           includeMergeCommits: true,
           gitDirectory: 'path/to/.git',
           startReference: 'foo',
           endReference: 'bar'
         });
 
-        m.chai.expect(command).to.equal([
-          'git --git-dir=path/to/.git log',
-          `--pretty="${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}"`,
+        m.chai.expect(command).to.deep.equal([
+          '--git-dir=path/to/.git',
+          'log',
+          `--pretty=${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}`,
           'foo..bar'
-        ].join(' '));
+        ]);
       });
 
     });
@@ -89,18 +90,19 @@ describe('GitLog', function() {
     describe('given both startReference and endReference options', function() {
 
       it('should construct the right command', function() {
-        const command = gitLog.getGitLogCommandThatOutputsYaml({
+        const command = gitLog.getGitLogCommandArgumentsThatOutputYaml({
           gitDirectory: 'path/to/.git',
           startReference: 'foo',
           endReference: 'bar'
         });
 
-        m.chai.expect(command).to.equal([
-          'git --git-dir=path/to/.git log',
-          `--pretty="${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}"`,
+        m.chai.expect(command).to.deep.equal([
+          '--git-dir=path/to/.git',
+          'log',
+          `--pretty=${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}`,
           '--no-merges',
           'foo..bar'
-        ].join(' '));
+        ]);
       });
 
     });
@@ -108,17 +110,18 @@ describe('GitLog', function() {
     describe('given startReference but no endReference option', function() {
 
       it('should construct the right command', function() {
-        const command = gitLog.getGitLogCommandThatOutputsYaml({
+        const command = gitLog.getGitLogCommandArgumentsThatOutputYaml({
           gitDirectory: 'path/to/.git',
           startReference: 'foo'
         });
 
-        m.chai.expect(command).to.equal([
-          'git --git-dir=path/to/.git log',
-          `--pretty="${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}"`,
+        m.chai.expect(command).to.deep.equal([
+          '--git-dir=path/to/.git',
+          'log',
+          `--pretty=${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}`,
           '--no-merges',
           'foo..HEAD'
-        ].join(' '));
+        ]);
       });
 
     });
@@ -126,17 +129,18 @@ describe('GitLog', function() {
     describe('given endReference but no startReference option', function() {
 
       it('should construct the right command', function() {
-        const command = gitLog.getGitLogCommandThatOutputsYaml({
+        const command = gitLog.getGitLogCommandArgumentsThatOutputYaml({
           gitDirectory: 'path/to/.git',
           endReference: 'foo'
         });
 
-        m.chai.expect(command).to.equal([
-          'git --git-dir=path/to/.git log',
-          `--pretty="${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}"`,
+        m.chai.expect(command).to.deep.equal([
+          '--git-dir=path/to/.git',
+          'log',
+          `--pretty=${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}`,
           '--no-merges',
           'foo'
-        ].join(' '));
+        ]);
       });
 
     });
@@ -144,16 +148,17 @@ describe('GitLog', function() {
     describe('given neither startReference nor endReference options', function() {
 
       it('should construct the right command', function() {
-        const command = gitLog.getGitLogCommandThatOutputsYaml({
+        const command = gitLog.getGitLogCommandArgumentsThatOutputYaml({
           gitDirectory: 'path/to/.git'
         });
 
-        m.chai.expect(command).to.equal([
-          'git --git-dir=path/to/.git log',
-          `--pretty="${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}"`,
+        m.chai.expect(command).to.deep.equal([
+          '--git-dir=path/to/.git',
+          'log',
+          `--pretty=${gitLog.GIT_LOG_YAML_PRETTY_FORMAT}`,
           '--no-merges',
           'HEAD'
-        ].join(' '));
+        ]);
       });
 
     });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -16,6 +16,8 @@
 
 'use strict';
 
+const _ = require('lodash');
+const EventEmitter = require('events').EventEmitter;
 const indentString = require('indent-string');
 
 /**
@@ -42,4 +44,25 @@ exports.formatCommit = (options) => {
     '    XXX',
     indentString(options.body, 4)
   ].join('\n');
+};
+
+/**
+ * @summary Create a ChildProcess object stub
+ * @function
+ * @public
+ *
+ * @returns {EventEmitter} ChildProcess stub
+ *
+ * @example
+ * const child = utils.createChildProcessStub();
+ * child.stdout.emit('foo');
+ */
+exports.createChildProcessStub = () => {
+  const child = new EventEmitter();
+
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = _.noop;
+
+  return child;
 };


### PR DESCRIPTION
`child_process.exec` imposes a limit on the largest amount of data allowed
on `stdout` or `stderr` (200 * 1024 bytes by default, according to the
documentation).

Since this limit can be easily reached when runnign Versionist on huge
projects, instead of executing the `git log` command, we spawn it, and
colelct the `stdout` output as it comes.

Change-Type: patch
Changelog-Entry: Fix `stdout maxBuffer exceeded` when parsing big logs.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>