### PR TITLE
chore: add versionist.conf.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ bower_components
 *.cer
 *.crt
 *.pem
-
-# Configuration Files
-*.conf.js

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -1,0 +1,23 @@
+module.exports = {
+
+  subjectParser: 'angular',
+
+  includeCommitWhen: (commit) => {
+    return commit.footer['Changelog-Entry'];
+  },
+
+  getIncrementLevelFromCommit: (commit) => {
+    return commit.footer['Change-Type'];
+  },
+
+  template: [
+    '## {{version}} - {{moment date "Y-MM-DD"}}',
+    '',
+    '{{#each commits}}',
+    '{{#with footer}}',
+    '- {{capitalize Changelog-Entry}}',
+    '{{/with}}',
+    '{{/each}}'
+  ].join('\n')
+
+};


### PR DESCRIPTION
We use a `versionist.conf.js` in Versionist's repo itself for
demonstration purposes.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>