### PR TITLE
feat: add simple default template

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -76,17 +76,23 @@ const CONFIGURATION = {
   },
   template: {
     type: 'string',
-    required: true
+    default: [
+      '## {{version}} - {{moment date "Y-MM-DD"}}',
+      '',
+      '{{#each commits}}',
+      '{{#if this.subject.title}}',
+      '- {{capitalize this.subject.title}}',
+      '{{else}}',
+      '- {{capitalize this.subject}}',
+      '{{/if}}',
+      '{{/each}}'
+    ].join('\n')
   }
 };
 
 const parseConfiguration = (data) => {
   return _.mapValues(CONFIGURATION, (propertyDescription, propertyName) => {
     const value = _.get(data, propertyName) || propertyDescription.default;
-
-    if (!value && propertyDescription.required) {
-      throw new Error(`Missing required option: ${propertyName}`);
-    }
 
     if (_.isString(value) && propertyDescription.allowsPresets) {
       const propertyPresets = _.get(presets, propertyName, {});


### PR DESCRIPTION
This means the `template` option is no longer required, and users can
get something to display in their terminals with really minimum
configuration.

Change-Type: minor
Changelog-Entry: Add a simple default template.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>