### PR TITLE
docs: template option is no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You may define the following options:
 
 ### `template (String)`
 
-**This option is required.**
+*Defaults to a simple demonstrational template.*
 
 This option takes a [Handlebars][handlebars] template. The following data is passed to it:
 


### PR DESCRIPTION
See: https://github.com/resin-io/versionist/pull/4
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>