### PR TITLE
fix: normalize template version

### DIFF
--- a/lib/semver.js
+++ b/lib/semver.js
@@ -140,6 +140,27 @@ exports.calculateNextIncrementLevel = (commits, options = {}) => {
 };
 
 /**
+ * @summary Normalize a semver version
+ * @function
+ * @public
+ *
+ * @param {String} version - version
+ * @returns {String} normalised version
+ *
+ * @example
+ * const version = semver.normalize('v1.0.0');
+ * console.log(version);
+ * > 1.0.0
+ */
+exports.normalize = (version) => {
+  if (!semver.valid(version)) {
+    throw new Error(`Invalid version: ${version}`);
+  }
+
+  return semver.clean(version);
+};
+
+/**
  * @summary Increment a version following semver
  * @function
  * @public

--- a/lib/versionist.js
+++ b/lib/versionist.js
@@ -210,7 +210,7 @@ exports.generateChangelog = (commits, options = {}) => {
 
   return template.render(options.template, {
     commits: _.filter(commits, options.includeCommitWhen),
-    version: options.version,
+    version: semver.normalize(options.version),
     date: options.date
   });
 };

--- a/tests/semver.spec.js
+++ b/tests/semver.spec.js
@@ -238,6 +238,24 @@ describe('Semver', function() {
 
   });
 
+  describe('.normalize()', function() {
+
+    it('should do nothing given a normalised version', function() {
+      m.chai.expect(semver.normalize('1.0.0')).to.equal('1.0.0');
+    });
+
+    it('should remove a leading `v` from the version', function() {
+      m.chai.expect(semver.normalize('v1.0.0')).to.equal('1.0.0');
+    });
+
+    it('should throw given an invalid version', function() {
+      m.chai.expect(() => {
+        semver.normalize('foo');
+      }).to.throw('Invalid version: foo');
+    });
+
+  });
+
   describe('.incrementVersion()', function() {
 
     it('should throw if the increment level is not valid', function() {

--- a/tests/versionist.spec.js
+++ b/tests/versionist.spec.js
@@ -279,6 +279,21 @@ describe('Versionist', function() {
       }).to.throw('No commits to generate the CHANGELOG from');
     });
 
+    it('should throw the version is invalid', function() {
+      m.chai.expect(() => {
+        versionist.generateChangelog([
+          {
+            subject: 'hello world'
+          }
+        ], {
+          includeCommitWhen: _.constant(true),
+          version: 'foo',
+          date: new Date(),
+          template: 'foo'
+        });
+      }).to.throw('Invalid version: foo');
+    });
+
     it('should throw if no version', function() {
       m.chai.expect(() => {
         versionist.generateChangelog([


### PR DESCRIPTION
We were currently blindly passing the version the user sets as the
`--current` option to the Handlebars template, without imposing any
validation or normalisation.

This would cause problems with invalid semver versions, or if the user
sometimes passes a version preppended with a `v` and sometimes not,
since the data passed to the template would not always be consistent.

This PR introduces a function called `semver.normalize()`, which returns
the normalised version, or throws if the version is not valid.

Change-Type: patch
Changelog-Entry: Normalize `--current` version before passing it to the template.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>