### PR TITLE
feat: add `addEntryToChangelog` option hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,23 @@ module.exports = {
 The whole commit object, after any transformations applied by `subjectParser`
 and `bodyParser` is passed as an argument.
 
+### `addEntryToChangelog (Function)`
+
+*Defaults to `prepend`.*
+
+You can declare this function to customise how the generated entry is added to
+your project's `CHANGELOG` file.
+
+If defined, the function takes three arguments:
+
+- `(String) file`: The `CHANGELOG` file path as declared in `changelogFile`.
+- `(String) entry`: The generated `CHANGELOG` entry.
+- `(Function) callback`: The callback function, which accepts an optional
+error.
+
+Notice that the `callback` should be **always** explicitly called, even if you
+declare a synchronous function.
+
 ### `includeMergeCommits (Boolean)`
 
 *Defaults to `false`.*
@@ -354,6 +371,14 @@ outputs an object containing the following properties: `type`, `scope` and
 This preset only includes commits whose `commit.subject.type` is either `feat`,
 `fix` or `perf`. It should be used in conjunction with `subjectParser`'s
 `angular` preset.
+
+### `addEntryToChangelog`
+
+- `prepend`
+
+This presets prepends the entry to the CHANGELOG file specified in
+`changelogFile`, taking care of not adding unnecessary blank lines between the
+current content and the new entry.
 
 Support
 -------

--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ module.exports = {
 };
 ```
 
+### `changelogFile (String)`
+
+*Defaults to `CHANGELOG.md`.*
+
+This option specifies the desired location of your `CHANGELOG` file, relative
+to the root of your project.
+
 ### `parseFooterTags (Boolean)`
 
 *Defaults to `true`.*

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,6 +24,7 @@
 
 const yargs = require('yargs');
 const _ = require('lodash');
+const async = require('async');
 const path = require('path');
 const chalk = require('chalk');
 const versionist = require('../lib/versionist');
@@ -76,6 +77,11 @@ const CONFIGURATION = {
   getIncrementLevelFromCommit: {
     type: 'function',
     default: _.constant(null),
+    allowsPresets: true
+  },
+  addEntryToChangelog: {
+    type: 'function',
+    default: 'prepend',
     allowsPresets: true
   },
   template: {
@@ -197,22 +203,34 @@ const argv = yargs
   })
   .argv;
 
-versionist.readCommitHistory(path.join(argv.config.path, argv.config.gitDirectory), {
-  startReference: argv.from,
-  endReference: argv.to,
-  subjectParser: argv.config.subjectParser,
-  bodyParser: argv.config.bodyParser
-}, (error, history) => {
+async.waterfall([
+
+  (callback) => {
+    versionist.readCommitHistory(path.join(argv.config.path, argv.config.gitDirectory), {
+      startReference: argv.from,
+      endReference: argv.to,
+      subjectParser: argv.config.subjectParser,
+      bodyParser: argv.config.bodyParser
+    }, callback);
+  },
+
+  (history, callback) => {
+    const entry = versionist.generateChangelog(history, {
+      template: argv.config.template,
+      includeCommitWhen: argv.config.includeCommitWhen,
+      version: versionist.calculateNextVersion(history, {
+        getIncrementLevelFromCommit: argv.config.getIncrementLevelFromCommit,
+        currentVersion: argv.current
+      })
+    });
+
+    argv.config.addEntryToChangelog(argv.config.changelogFile, entry, callback);
+  }
+
+], (error) => {
   if (error) {
     return showErrorAndQuit(error);
   }
 
-  console.log(versionist.generateChangelog(history, {
-    template: argv.config.template,
-    includeCommitWhen: argv.config.includeCommitWhen,
-    version: versionist.calculateNextVersion(history, {
-      getIncrementLevelFromCommit: argv.config.getIncrementLevelFromCommit,
-      currentVersion: argv.current
-    })
-  }));
+  console.log('Done');
 });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,6 +42,10 @@ const CONFIGURATION = {
     type: 'string',
     default: process.cwd()
   },
+  changelogFile: {
+    type: 'string',
+    default: 'CHANGELOG.md'
+  },
   gitDirectory: {
     type: 'string',
     default: '.git'

--- a/lib/presets.js
+++ b/lib/presets.js
@@ -21,6 +21,9 @@
  */
 
 const _ = require('lodash');
+const async = require('async');
+const touch = require('touch');
+const fs = require('fs');
 
 module.exports = {
 
@@ -102,6 +105,53 @@ module.exports = {
         'fix',
         'perf'
       ], commit.subject.type);
+    }
+
+  },
+
+  addEntryToChangelog: {
+
+    /**
+     * @summary Prepend entry to CHANGELOG
+     * @function
+     * @public
+     *
+     * @param {String} file - changelog file path
+     * @param {String} entry - changelog entry
+     * @param {Function} callback - callback
+     *
+     * @example
+     * presets.addEntryToChangelog.prepend('changelog.md', 'My Entry\n', (error) => {
+     *   if (error) {
+     *     throw error;
+     *   }
+     * });
+     */
+    prepend: (file, entry, callback) => {
+      async.waterfall([
+        _.partial(touch, file, {}),
+
+        (touchedFiles, done) => {
+          fs.readFile(file, {
+            encoding: 'utf8'
+          }, done);
+        },
+
+        (contents, done) => {
+          const entryWithoutTrailingSpace = entry.replace(/(\n)+$/, '');
+          const changelogWithoutLeadingSpace = contents.replace(/^(\n)+/, '');
+
+          return done(null, _.attempt(() => {
+            if (_.isEmpty(changelogWithoutLeadingSpace)) {
+              return entryWithoutTrailingSpace;
+            }
+
+            return entryWithoutTrailingSpace + '\n\n' + changelogWithoutLeadingSpace;
+          }));
+        },
+
+        _.partial(fs.writeFile, file)
+      ], callback);
     }
 
   }

--- a/package.json
+++ b/package.json
@@ -22,15 +22,18 @@
     "eslint": "^3.0.0",
     "indent-string": "^3.0.0",
     "mocha": "^2.5.3",
-    "mochainon": "^1.0.0"
+    "mochainon": "^1.0.0",
+    "tmp": "0.0.28"
   },
   "dependencies": {
+    "async": "^2.0.0-rc.6",
     "chalk": "^1.1.3",
     "handlebars": "^4.0.5",
     "handlebars-helpers": "^0.6.1",
     "js-yaml": "^3.6.1",
     "lodash": "^4.13.1",
     "semver": "^5.2.0",
+    "touch": "^1.0.0",
     "yargs": "^4.7.1"
   }
 }

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -17,6 +17,8 @@
 'use strict';
 
 const m = require('mochainon');
+const fs = require('fs');
+const tmp = require('tmp');
 const presets = require('../lib/presets');
 
 describe('Presets', function() {
@@ -207,6 +209,198 @@ describe('Presets', function() {
         m.chai.expect(presets.includeCommitWhen.angular({
           subject: 'foobar($ngRepeat): hello world'
         })).to.be.false;
+      });
+
+    });
+
+  });
+
+  describe('.addEntryToChangelog', function() {
+
+    describe('.prepend', function() {
+
+      describe('given the file does not exist', function() {
+
+        beforeEach(function() {
+          this.tmp = tmp.tmpNameSync();
+        });
+
+        afterEach(function() {
+          fs.unlinkSync(this.tmp);
+        });
+
+        it('should create the file', function(done) {
+          presets.addEntryToChangelog.prepend(this.tmp, [
+            'Lorem ipsum'
+          ].join('\n'), (error) => {
+            m.chai.expect(error).to.not.exist;
+
+            const contents = fs.readFileSync(this.tmp, {
+              encoding: 'utf8'
+            });
+
+            m.chai.expect(contents).to.equal([
+              'Lorem ipsum'
+            ].join('\n'));
+
+            done();
+          });
+        });
+
+      });
+
+      describe('given a temporary file with contents', function() {
+
+        beforeEach(function() {
+          this.tmp = tmp.fileSync();
+          fs.writeFileSync(this.tmp.fd, 'Foo Bar\nHello World');
+        });
+
+        afterEach(function() {
+          this.tmp.removeCallback();
+        });
+
+        it('should not add a white line if not necessary', function(done) {
+          presets.addEntryToChangelog.prepend(this.tmp.name, [
+            'Lorem ipsum',
+            ''
+          ].join('\n'), (error) => {
+            m.chai.expect(error).to.not.exist;
+
+            const contents = fs.readFileSync(this.tmp.name, {
+              encoding: 'utf8'
+            });
+
+            m.chai.expect(contents).to.equal([
+              'Lorem ipsum',
+              '',
+              'Foo Bar',
+              'Hello World'
+            ].join('\n'));
+
+            done();
+          });
+        });
+
+        it('should add a white line if necessary', function(done) {
+          presets.addEntryToChangelog.prepend(this.tmp.name, [
+            'Lorem ipsum'
+          ].join('\n'), (error) => {
+            m.chai.expect(error).to.not.exist;
+
+            const contents = fs.readFileSync(this.tmp.name, {
+              encoding: 'utf8'
+            });
+
+            m.chai.expect(contents).to.equal([
+              'Lorem ipsum',
+              '',
+              'Foo Bar',
+              'Hello World'
+            ].join('\n'));
+
+            done();
+          });
+        });
+
+        it('should remove extra white lines', function(done) {
+          presets.addEntryToChangelog.prepend(this.tmp.name, [
+            'Lorem ipsum',
+            '',
+            '',
+            ''
+          ].join('\n'), (error) => {
+            m.chai.expect(error).to.not.exist;
+
+            const contents = fs.readFileSync(this.tmp.name, {
+              encoding: 'utf8'
+            });
+
+            m.chai.expect(contents).to.equal([
+              'Lorem ipsum',
+              '',
+              'Foo Bar',
+              'Hello World'
+            ].join('\n'));
+
+            done();
+          });
+        });
+
+      });
+
+      describe('given a temporary file with contents and leading white lines', function() {
+
+        beforeEach(function() {
+          this.tmp = tmp.fileSync();
+          fs.writeFileSync(this.tmp.fd, '\n\n\nFoo Bar\nHello World');
+        });
+
+        afterEach(function() {
+          this.tmp.removeCallback();
+        });
+
+        it('should normalize white lines', function(done) {
+          presets.addEntryToChangelog.prepend(this.tmp.name, [
+            'Lorem ipsum',
+            '',
+            '',
+            ''
+          ].join('\n'), (error) => {
+            m.chai.expect(error).to.not.exist;
+
+            const contents = fs.readFileSync(this.tmp.name, {
+              encoding: 'utf8'
+            });
+
+            m.chai.expect(contents).to.equal([
+              'Lorem ipsum',
+              '',
+              'Foo Bar',
+              'Hello World'
+            ].join('\n'));
+
+            done();
+          });
+        });
+
+      });
+
+      describe('given a temporary file with contents and trailing white lines', function() {
+
+        beforeEach(function() {
+          this.tmp = tmp.fileSync();
+          fs.writeFileSync(this.tmp.fd, 'Foo Bar\nHello World\n\n');
+        });
+
+        afterEach(function() {
+          this.tmp.removeCallback();
+        });
+
+        it('should keep the trailing white lines intact', function(done) {
+          presets.addEntryToChangelog.prepend(this.tmp.name, [
+            'Lorem ipsum'
+          ].join('\n'), (error) => {
+            m.chai.expect(error).to.not.exist;
+
+            const contents = fs.readFileSync(this.tmp.name, {
+              encoding: 'utf8'
+            });
+
+            m.chai.expect(contents).to.equal([
+              'Lorem ipsum',
+              '',
+              'Foo Bar',
+              'Hello World',
+              '',
+              ''
+            ].join('\n'));
+
+            done();
+          });
+
+        });
+
       });
 
     });


### PR DESCRIPTION
This hooks is used to determine how the CHANGELOG generated by Versionist
is added to the project's CHANGELOG file.

It ships with a `prepend` preset, which as the name implies, simply
prepends the entry to the CHANGELOG file specified with `changelogFile`,
which uses as a default value..

Change-Type: minor
Changelog-Entry: Add `addEntryToChangelog` option hook.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>