### PR TITLE
feat: make changelog entry addition idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,17 @@ declare a synchronous function.
 
 When this option is enabled, merge commits will be included in the `CHANGELOG`.
 
+### `getChangelogDocumentedVersions (Function)`
+
+*Defaults to `changelog-headers`.*
+
+You can declare this function to customise how Versionist determines which
+versions were already documented in the `CHANGELOG` file.
+
+The function takes the `CHANGELOG` file as set in `changelogFile` and callback
+as parameters. The latter should be called with an optional error and an array
+of semantic version strings.
+
 ### `getIncrementLevelFromCommit (Function)`
 
 *Defaults to a function that always returns `null`.*
@@ -373,6 +384,13 @@ Versionist by default.k
 This preset parses the subject according to Angular's commit guidelines. It
 outputs an object containing the following properties: `type`, `scope` and
 `title`.
+
+### `getChangelogDocumentedVersions`
+
+- `changelog-headers`
+
+This preset parses the `CHANGELOG` file specified in `changelogFile`, and
+extracts any valid semantic versions from the headers.
 
 ### `includeCommitWhen`
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ error.
 Notice that the `callback` should be **always** explicitly called, even if you
 declare a synchronous function.
 
+If the final version (either as specified in `--current` or calculated by
+`getIncrementLevelFromCommit`) is already returned by the hooks, then the entry
+is not added the the `CHANGELOG`.
+
 ### `includeMergeCommits (Boolean)`
 
 *Defaults to `false`.*

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -220,16 +220,29 @@ async.waterfall([
   },
 
   (history, callback) => {
-    const entry = versionist.generateChangelog(history, {
-      template: argv.config.template,
-      includeCommitWhen: argv.config.includeCommitWhen,
-      version: versionist.calculateNextVersion(history, {
-        getIncrementLevelFromCommit: argv.config.getIncrementLevelFromCommit,
-        currentVersion: argv.current
-      })
+    const version = versionist.calculateNextVersion(history, {
+      getIncrementLevelFromCommit: argv.config.getIncrementLevelFromCommit,
+      currentVersion: argv.current
     });
 
-    argv.config.addEntryToChangelog(argv.config.changelogFile, entry, callback);
+    argv.config.getChangelogDocumentedVersions(argv.config.changelogFile, (error, documentedVersions) => {
+      if (error) {
+        return callback(error);
+      }
+
+      if (_.includes(documentedVersions, version)) {
+        console.log(`Omitting: ${version}`);
+        return callback();
+      }
+
+      const entry = versionist.generateChangelog(history, {
+        template: argv.config.template,
+        includeCommitWhen: argv.config.includeCommitWhen,
+        version: version
+      });
+
+      argv.config.addEntryToChangelog(argv.config.changelogFile, entry, callback);
+    });
   }
 
 ], (error) => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -74,6 +74,11 @@ const CONFIGURATION = {
     type: 'boolean',
     default: false
   },
+  getChangelogDocumentedVersions: {
+    type: 'function',
+    default: 'changelog-headers',
+    allowsPresets: true
+  },
   getIncrementLevelFromCommit: {
     type: 'function',
     default: _.constant(null),

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * @module Versionist.Markdown
+ */
+
+const _ = require('lodash');
+const markdown = require('markdown').markdown;
+
+/**
+ * @summary Extract node content
+ * @function
+ * @private
+ *
+ * @param {String[]} node - node
+ * @returns {String[]} node content
+ */
+const extractNodeContent = (node) => {
+  return _.slice(node, 2);
+};
+
+/**
+ * @summary Extract text from node
+ * @function
+ * @private
+ *
+ * @param {String[]} node - node
+ * @returns {String} node text
+ */
+const extractNodeText = (node) => {
+  return _.join(_.flattenDeep(_.map(node, (content) => {
+    if (_.isArray(content)) {
+      return extractNodeContent(content);
+    }
+
+    return content;
+  })), '');
+};
+
+/**
+ * @summary Extract titles from markdown tree
+ * @function
+ * @private
+ *
+ * @param {Any[]} nodes - nodes
+ * @returns {String[]} titles
+ */
+const extractTitlesFromTree = (nodes) => {
+  return _.reduce(nodes, (accumulator, node) => {
+    const nodeType = _.first(node);
+
+    if (nodeType === 'header') {
+      const headerContents = extractNodeContent(node);
+      accumulator.push(extractNodeText(headerContents));
+    }
+
+    if (_.isArray(node)) {
+      accumulator = _.union(accumulator, extractTitlesFromTree(node));
+    }
+
+    return accumulator;
+  }, []);
+};
+
+/**
+ * @summary Extract titles from a markdown document
+ * @function
+ * @public
+ *
+ * @param {String} text - markdown text
+ * @returns {String[]} titles
+ *
+ * @example
+ * const titles = markdown.extractTitles([
+ *   '# My markdown document',
+ *   '',
+ *   'Hello world!'
+ * ].join('\n'));
+ */
+exports.extractTitles = _.flow([
+  markdown.parse,
+  extractTitlesFromTree
+]);

--- a/lib/presets.js
+++ b/lib/presets.js
@@ -24,6 +24,8 @@ const _ = require('lodash');
 const async = require('async');
 const touch = require('touch');
 const fs = require('fs');
+const semver = require('semver');
+const markdown = require('./markdown');
 
 module.exports = {
 
@@ -105,6 +107,47 @@ module.exports = {
         'fix',
         'perf'
       ], commit.subject.type);
+    }
+
+  },
+
+  getChangelogDocumentedVersions: {
+
+    /**
+     * @summary Get CHANGELOG documented versions from CHANGELOG titles
+     * @function
+     * @public
+     *
+     * @param {String} file - changelog file
+     * @param {Function} callback - callback (error, versions)
+     *
+     * @example
+     * presets.getChangelogDocumentedVersions['changelog-headers']('CHANGELOG.md', (error, versions) => {
+     *   if (error) {
+     *     throw error;
+     *   }
+     *
+     *   console.log(versions);
+     * });
+     */
+    'changelog-headers': (file, callback) => {
+      fs.readFile(file, {
+        encoding: 'utf8'
+      }, (error, changelog) => {
+        if (error) {
+          return callback(error);
+        }
+
+        const versions = _.chain(markdown.extractTitles(changelog))
+          .map((title) => {
+            return _.filter(_.split(title, ' '), semver.valid);
+          })
+          .flattenDeep()
+          .map(semver.clean)
+          .value();
+
+        return callback(null, versions);
+      });
     }
 
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "handlebars-helpers": "^0.6.1",
     "js-yaml": "^3.6.1",
     "lodash": "^4.13.1",
+    "markdown": "^0.5.0",
     "semver": "^5.2.0",
     "touch": "^1.0.0",
     "yargs": "^4.7.1"

--- a/tests/markdown.spec.js
+++ b/tests/markdown.spec.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const markdown = require('../lib/markdown');
+
+describe('Markdown', function() {
+
+  describe('.extractTitles()', function() {
+
+    it('should return an empty array if no titles', function() {
+      const titles = markdown.extractTitles([
+        'Hello World',
+        '',
+        'Lorem ipsum dolor sit amet'
+      ].join('\n'));
+
+      m.chai.expect(titles).to.deep.equal([]);
+    });
+
+    it('should parse titles with links', function() {
+      const titles = markdown.extractTitles([
+        '# [Hello](http://www.google.com) World',
+        'Foo bar',
+        '',
+        '# Hey [there](http://yahoo.com)',
+        'Bar baz',
+        '',
+        '# [Hola mundo](http://bing.com)',
+        'Baz qux'
+      ].join('\n'));
+
+      m.chai.expect(titles).to.deep.equal([
+        'Hello World',
+        'Hey there',
+        'Hola mundo'
+      ]);
+    });
+
+    it('should parse top-level titles in atx style', function() {
+      const titles = markdown.extractTitles([
+        '# Hello World',
+        'Foo bar',
+        '',
+        '# Hey there',
+        'Bar baz'
+      ].join('\n'));
+
+      m.chai.expect(titles).to.deep.equal([
+        'Hello World',
+        'Hey there'
+      ]);
+    });
+
+    it('should parse top-level titles in setext style', function() {
+      const titles = markdown.extractTitles([
+        'Hello World',
+        '===========',
+        'Foo bar',
+        '',
+        'Hey there',
+        '=========',
+        'Bar baz'
+      ].join('\n'));
+
+      m.chai.expect(titles).to.deep.equal([
+        'Hello World',
+        'Hey there'
+      ]);
+    });
+
+    it('should parse nested titles in atx style', function() {
+      const titles = markdown.extractTitles([
+        '# Hello world',
+        'Foo bar',
+        '',
+        '## Hey there',
+        'Bar baz',
+        '',
+        '### Hola mundo',
+        'Foo bar'
+      ].join('\n'));
+
+      m.chai.expect(titles).to.deep.equal([
+        'Hello world',
+        'Hey there',
+        'Hola mundo'
+      ]);
+    });
+
+    it('should parse nested titles in setext style', function() {
+      const titles = markdown.extractTitles([
+        'Hello world',
+        '===========',
+        'Foo bar',
+        '',
+        'Hey there',
+        '---------',
+        'Bar baz',
+        '',
+        '### Hola mundo',
+        'Foo bar'
+      ].join('\n'));
+
+      m.chai.expect(titles).to.deep.equal([
+        'Hello world',
+        'Hey there',
+        'Hola mundo'
+      ]);
+    });
+
+  });
+
+});

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -215,6 +215,145 @@ describe('Presets', function() {
 
   });
 
+  describe('.getChangelogDocumentedVersions', function() {
+
+    describe('.`changelog-headers`', function() {
+
+      describe('given there was an error reading the file', function() {
+
+        beforeEach(function() {
+          this.fsReadFileStub = m.sinon.stub(fs, 'readFile');
+          this.fsReadFileStub.yields(new Error('read error'));
+        });
+
+        afterEach(function() {
+          this.fsReadFileStub.restore();
+        });
+
+        it('should yield back the error', function(done) {
+          const fn = presets.getChangelogDocumentedVersions['changelog-headers'];
+          fn('CHANGELOG.md', (error, versions) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.message).to.equal('read error');
+            m.chai.expect(versions).to.not.exist;
+            done();
+          });
+        });
+
+      });
+
+      describe('given the file contained versions as headers', function() {
+
+        beforeEach(function() {
+          this.fsReadFileStub = m.sinon.stub(fs, 'readFile');
+          this.fsReadFileStub.yields(null, [
+            '# My markdown document',
+            '',
+            '## 1.1.0',
+            '',
+            '- foo',
+            '',
+            '## 1.0.0',
+            '',
+            '- foo'
+          ].join('\n'));
+        });
+
+        afterEach(function() {
+          this.fsReadFileStub.restore();
+        });
+
+        it('should yield the documented versions', function(done) {
+          const fn = presets.getChangelogDocumentedVersions['changelog-headers'];
+          fn('CHANGELOG.md', (error, versions) => {
+            m.chai.expect(error).to.not.exist;
+            m.chai.expect(versions).to.deep.equal([
+              '1.1.0',
+              '1.0.0'
+            ]);
+            done();
+          });
+
+        });
+
+      });
+
+      describe('given the file contained non-normalised versions as headers', function() {
+
+        beforeEach(function() {
+          this.fsReadFileStub = m.sinon.stub(fs, 'readFile');
+          this.fsReadFileStub.yields(null, [
+            '# My markdown document',
+            '',
+            '## v1.1.0',
+            '',
+            '- foo',
+            '',
+            '## v1.0.0',
+            '',
+            '- foo'
+          ].join('\n'));
+        });
+
+        afterEach(function() {
+          this.fsReadFileStub.restore();
+        });
+
+        it('should normalize the versions', function(done) {
+          const fn = presets.getChangelogDocumentedVersions['changelog-headers'];
+          fn('CHANGELOG.md', (error, versions) => {
+            m.chai.expect(error).to.not.exist;
+            m.chai.expect(versions).to.deep.equal([
+              '1.1.0',
+              '1.0.0'
+            ]);
+            done();
+          });
+
+        });
+
+      });
+
+      describe('given the file contained versions plus other text as headers', function() {
+
+        beforeEach(function() {
+          this.fsReadFileStub = m.sinon.stub(fs, 'readFile');
+          this.fsReadFileStub.yields(null, [
+            '# My markdown document',
+            '',
+            '## Foo 1.1.0',
+            '',
+            '- foo',
+            '',
+            '## 1.0.0 Bar',
+            '',
+            '- foo'
+          ].join('\n'));
+        });
+
+        afterEach(function() {
+          this.fsReadFileStub.restore();
+        });
+
+        it('should yield the documented versions', function(done) {
+          const fn = presets.getChangelogDocumentedVersions['changelog-headers'];
+          fn('CHANGELOG.md', (error, versions) => {
+            m.chai.expect(error).to.not.exist;
+            m.chai.expect(versions).to.deep.equal([
+              '1.1.0',
+              '1.0.0'
+            ]);
+            done();
+          });
+
+        });
+
+      });
+
+    });
+
+  });
+
   describe('.addEntryToChangelog', function() {
 
     describe('.prepend', function() {


### PR DESCRIPTION
Currently, a generated entry is blindly added to the `CHANGELOG` file. This
means that if a user runs the same command over and over again, the same
duplicated entry will be added to the `CHANGELOG` multiple times.

This commit makes use of `getChangelogDocumentedVersions` to determine
whether the calculated version should be added to the CHANGELOG or not.

Change-Type: patch
Changelog-Entry: Make CHANGELOG entry addition idempotent.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>