### PR TITLE
fix: apply default values if the current value is not defined

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -102,7 +102,15 @@ const CONFIGURATION = {
 
 const parseConfiguration = (data) => {
   return _.mapValues(CONFIGURATION, (propertyDescription, propertyName) => {
-    const value = _.get(data, propertyName) || propertyDescription.default;
+    const value = _.attempt(() => {
+      const currentValue = _.get(data, propertyName);
+
+      if (_.isUndefined(currentValue) || _.isNull(currentValue)) {
+        return propertyDescription.default;
+      }
+
+      return currentValue;
+    });
 
     if (_.isString(value) && propertyDescription.allowsPresets) {
       const propertyPresets = _.get(presets, propertyName, {});


### PR DESCRIPTION
There is a bug in the way we apply default values for boolean options.
If the user explicitly sets an option to `false`, then `property ||
default` will incorrectly be evaluated to `default`, which might be
`true.

Change-Type: patch
Changelog-Entry: Don't apply default values on boolean options explicitly set to `false`.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>