### PR TITLE
feat: add `editChangelog` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ module.exports = {
 This option specifies the desired location of your `CHANGELOG` file, relative
 to the root of your project.
 
+### `editChangelog (Boolean)`
+
+*Defaults to `true`.*
+
+When this option is enabled, your project's `CHANGELOG` file, as specified in
+`changelogFile`, it automatically edited as configured in
+`addEntryToChangelog`.
+
+If this option is disabled, the generated entry is printed to `stdout`.
+
 ### `parseFooterTags (Boolean)`
 
 *Defaults to `true`.*

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -56,6 +56,10 @@ const CONFIGURATION = {
     type: 'boolean',
     default: true
   },
+  editChangelog: {
+    type: 'boolean',
+    default: true
+  },
   subjectParser: {
     type: 'function',
     default: _.identity,
@@ -245,7 +249,11 @@ async.waterfall([
       version: version
     });
 
-    argv.config.addEntryToChangelog(argv.config.changelogFile, entry, callback);
+    if (argv.config.editChangelog) {
+      argv.config.addEntryToChangelog(argv.config.changelogFile, entry, callback);
+    } else {
+      console.log(entry);
+    }
   }
 
 ], (error) => {


### PR DESCRIPTION
This function makes Versionist add the generated entry to the CHANGELOG
automatically, which is the default behaviour.

Instead, if the option is set to `false`, the generated entry is simply
printed to `stdout`, which is very useful for debugging purposes, or
while the user is working on its template.

Change-Type: minor
Changelog-Entry: Add `editChangelog` option.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>