### PR TITLE
feat: infer `--from` and `--to`

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,15 @@ has been made), and should return either `major`, `minor` or `patch`.
 If the increment level returned from this function is not defined, the commit
 will not alter the final version.
 
+### `getGitReferenceFromVersion (Function)`
+
+*Defaults to the identity function.*
+
+Declare this function to resolve a git reference from a semantic version. If
+you add `x.y.z` annotated git tags you should not need to specify this hooks,
+however it can be handy if you have other conventions, like prefixing the
+version with `v`, etc.
+
 ### `path (String)`
 
 *Defaults to `$CWD`.*
@@ -411,6 +420,12 @@ This preset only includes commits whose `commit.subject.type` is either `feat`,
 This presets prepends the entry to the CHANGELOG file specified in
 `changelogFile`, taking care of not adding unnecessary blank lines between the
 current content and the new entry.
+
+### `getGitReferenceFromVersion`
+
+- `v-prefix`
+
+This presets simply prepends `v` to the version.
 
 Support
 -------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ cd versionist
 - Run Versionist
 
 ```
-$ versionist -u 1.0.0
+$ versionist
 ```
 
 ***
@@ -76,33 +76,11 @@ Options:
   --help, -h     show help
   --version, -v  show version number
   --config, -c   configuration file
-  --from, -f     start reference
-  --to, -t       end reference
   --current, -u  current version
 
 Examples:
-  versionist --from v1.0.0 --to v1.1.0 --current 1.1.0
+  versionist --current 1.1.0
 ```
-
-Versionist will output the resulting entry to `stdout`, being your
-responsibility to append/preppend or include it the way you like in your
-project's main `CHANGELOG` file.
-
-### `--from`/`--to`
-
-These command line options allow you to select the exact range of commits
-you're interested in when attempting to generate your `CHANGELOG`. They can be
-any reference that git understands, like git tags, commit hashes, branch names,
-etc.
-
-- If you omit `--to`: Versionist will take every commit from the `--from`
-reference until `HEAD`.
-
-- If you omit `--from`: Versionist will take every commit since the beginning
-of the project, until the reference you passed to `--to`.
-
-- If you omit both `--to` and `--from`: Versionist will retrieve the whole
-history from your project, which is rarely what you want.
 
 ### `--current`
 
@@ -111,6 +89,9 @@ of your project.
 
 If you are making use of `getIncrementLevelFromCommit`, you'll want to pass the
 version number *before* the release, so it gets incremented automatically.
+
+If omitted, `--current` will equal the greater version from the versions
+returned by the `getChangelogDocumentedVersions` hook.
 
 ### `--config`
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -84,6 +84,11 @@ const CONFIGURATION = {
     default: _.constant(null),
     allowsPresets: true
   },
+  getGitReferenceFromVersion: {
+    type: 'function',
+    default: _.identity,
+    allowsPresets: true
+  },
   addEntryToChangelog: {
     type: 'function',
     default: 'prepend',

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,6 +29,7 @@ const path = require('path');
 const chalk = require('chalk');
 const versionist = require('../lib/versionist');
 const presets = require('../lib/presets');
+const semver = require('../lib/semver');
 const packageJSON = require('../package.json');
 
 const showErrorAndQuit = (error) => {
@@ -177,21 +178,10 @@ const argv = yargs
     }
   })
   .options({
-    from: {
-      describe: 'start reference',
-      string: true,
-      alias: 'f'
-    },
-    to: {
-      describe: 'end reference',
-      string: true,
-      alias: 't'
-    },
     current: {
       describe: 'current version',
       string: true,
-      alias: 'u',
-      required: true
+      alias: 'u'
     },
     config: {
       describe: 'configuration file',
@@ -210,7 +200,7 @@ const argv = yargs
       alias: 'v'
     }
   })
-  .example('$0 --from v1.0.0 --to v1.1.0 --current 1.1.0')
+  .example('$0 --current 1.1.0')
   .fail((message) => {
 
     // Prints to `stderr` by default
@@ -224,38 +214,38 @@ const argv = yargs
 async.waterfall([
 
   (callback) => {
-    versionist.readCommitHistory(path.join(argv.config.path, argv.config.gitDirectory), {
-      startReference: argv.from,
-      endReference: argv.to,
-      subjectParser: argv.config.subjectParser,
-      bodyParser: argv.config.bodyParser
-    }, callback);
+    argv.config.getChangelogDocumentedVersions(argv.config.changelogFile, callback);
   },
 
-  (history, callback) => {
+  (documentedVersions, callback) => {
+    versionist.readCommitHistory(path.join(argv.config.path, argv.config.gitDirectory), {
+      startReference: argv.config.getGitReferenceFromVersion(semver.getGreaterVersion(documentedVersions)),
+      endReference: 'HEAD',
+      subjectParser: argv.config.subjectParser,
+      bodyParser: argv.config.bodyParser
+    }, (error, history) => {
+      return callback(error, documentedVersions, history);
+    });
+  },
+
+  (documentedVersions, history, callback) => {
     const version = versionist.calculateNextVersion(history, {
       getIncrementLevelFromCommit: argv.config.getIncrementLevelFromCommit,
-      currentVersion: argv.current
+      currentVersion: argv.current || semver.getGreaterVersion(documentedVersions)
     });
 
-    argv.config.getChangelogDocumentedVersions(argv.config.changelogFile, (error, documentedVersions) => {
-      if (error) {
-        return callback(error);
-      }
+    if (_.includes(documentedVersions, version)) {
+      console.log(`Omitting: ${version}`);
+      return callback();
+    }
 
-      if (_.includes(documentedVersions, version)) {
-        console.log(`Omitting: ${version}`);
-        return callback();
-      }
-
-      const entry = versionist.generateChangelog(history, {
-        template: argv.config.template,
-        includeCommitWhen: argv.config.includeCommitWhen,
-        version: version
-      });
-
-      argv.config.addEntryToChangelog(argv.config.changelogFile, entry, callback);
+    const entry = versionist.generateChangelog(history, {
+      template: argv.config.template,
+      includeCommitWhen: argv.config.includeCommitWhen,
+      version: version
     });
+
+    argv.config.addEntryToChangelog(argv.config.changelogFile, entry, callback);
   }
 
 ], (error) => {

--- a/lib/presets.js
+++ b/lib/presets.js
@@ -197,6 +197,31 @@ module.exports = {
       ], callback);
     }
 
+  },
+
+  getGitReferenceFromVersion: {
+
+    /**
+     * @summary Add a `v` prefix to the version
+     * @function
+     * @public
+     *
+     * @param {String} version - version
+     * @returns {String} git reference
+     *
+     * @example
+     * const reference = presets.getGitReferenceFromVersion['v-prefix']('1.0.0');
+     * console.log(reference);
+     * > v1.0.0
+     */
+    'v-prefix': (version) => {
+      if (_.startsWith(version, 'v')) {
+        return version;
+      }
+
+      return `v${version}`;
+    }
+
   }
 
 };

--- a/lib/semver.js
+++ b/lib/semver.js
@@ -185,3 +185,27 @@ exports.incrementVersion = (version, incrementLevel) => {
 
   return semver.inc(version, incrementLevel);
 };
+
+/**
+ * @summary Get greater semantic version
+ * @function
+ * @public
+ *
+ * @param {String[]} versions - versions
+ * @returns {String} greater version
+ *
+ * @example
+ * const version = semver.getGreaterVersion([
+ *   '2.1.1',
+ *   '2.1.0',
+ *   '2.0.0'
+ * ]);
+ *
+ * console.log(version);
+ * > 2.1.1
+ */
+exports.getGreaterVersion = (versions) => {
+  return _.trim(_.reduce(versions, (current, version) => {
+    return semver.gt(version, current) ? version : current;
+  }, '0.0.0'));
+};

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -546,4 +546,22 @@ describe('Presets', function() {
 
   });
 
+  describe('.getGitReferenceFromVersion', function() {
+
+    describe('.`v-prefix`', function() {
+
+      it('should prepend a `v` to the version', function() {
+        const version = presets.getGitReferenceFromVersion['v-prefix']('1.0.0');
+        m.chai.expect(version).to.equal('v1.0.0');
+      });
+
+      it('should not prepend a `v` to the version if it already has one', function() {
+        const version = presets.getGitReferenceFromVersion['v-prefix']('v1.0.0');
+        m.chai.expect(version).to.equal('v1.0.0');
+      });
+
+    });
+
+  });
+
 });

--- a/tests/semver.spec.js
+++ b/tests/semver.spec.js
@@ -292,4 +292,43 @@ describe('Semver', function() {
 
   });
 
+  describe('.getGreaterVersion()', function() {
+
+    it('should throw if there is an invalid version', function() {
+      m.chai.expect(() => {
+        semver.getGreaterVersion([
+          '=====',
+          '1.0.0'
+        ]);
+      }).to.throw('Invalid Version: =====');
+    });
+
+    it('should return the greater version', function() {
+      const greater = semver.getGreaterVersion([
+        '2.0.0',
+        '1.1.1',
+        '1.9.0-beta.1',
+        '2.0.1',
+        '2.1.1',
+        '1.0.0'
+      ]);
+
+      m.chai.expect(greater).to.equal('2.1.1');
+    });
+
+    it('should deal with non-normalised versions', function() {
+      const greater = semver.getGreaterVersion([
+        '2.0.0',
+        'v1.1.1',
+        '1.9.0-beta.1',
+        '  2.0.1',
+        '2.1.1   ',
+        'v1.0.0'
+      ]);
+
+      m.chai.expect(greater).to.equal('2.1.1');
+    });
+
+  });
+
 });

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -2,6 +2,8 @@ module.exports = {
 
   subjectParser: 'angular',
 
+  getGitReferenceFromVersion: 'v-prefix',
+
   includeCommitWhen: (commit) => {
     return commit.footer['Changelog-Entry'];
   },


### PR DESCRIPTION
Using Versionist is very manual. We require users to manually specify the
range of commits to be parsed with the `--from` and `--to` CLI arguments.

Since the addition of the `getChangelogDocumentedVersions` hook, we can use
the information returned by that function to automatically infer these
values.

The CLI doesn't have the `--from`/`--to` options anymore and instead:

- Defaults `--to` to `HEAD`.
- Defaults `--from` to the greater version returned by
`getChangelogDocumentedVersions`.

Change-Type: major
Changelog-Entry: Automatically infer the appropriate git commit range.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>