### PR TITLE
chore: remove CHANGELOG header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/).
-
 ## 1.1.0 - 2016-07-08
 
 - Add a simple default template.


### PR DESCRIPTION
For simplicity purposes. We'll be extending presets to take arguments
shortly, which would allows to deal with this edge case with the
`addEntryToChangelog`'s `prepend` preset.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>