### PR TITLE
refactor: use semver.compare to sort versions

### DIFF
--- a/lib/semver.js
+++ b/lib/semver.js
@@ -205,7 +205,5 @@ exports.incrementVersion = (version, incrementLevel) => {
  * > 2.1.1
  */
 exports.getGreaterVersion = (versions) => {
-  return _.trim(_.reduce(versions, (current, version) => {
-    return semver.gt(version, current) ? version : current;
-  }, '0.0.0'));
+  return _.trim(_.last(versions.sort(semver.compare)));
 };


### PR DESCRIPTION
`semver.compare` can be passed to `Array#sort()` directly, which greatly
simplifies our reducer function uses `semver.gt`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>