### PR TITLE
Add `updateVersion` and `editVersion` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,19 @@ you add `x.y.z` annotated git tags you should not need to specify this hooks,
 however it can be handy if you have other conventions, like prefixing the
 version with `v`, etc.
 
+### `updateVersion (Function)`
+
+*Defaults to the `npm`.*
+
+Declare this function to specify how Versionist should update your project's
+version.
+
+The function takes three arguments:
+
+- `(String) cwd`: The current working directory.
+- `(String) version`: The new version.
+- `(Function) callback`: The callback.
+
 ### `path (String)`
 
 *Defaults to `$CWD`.*
@@ -417,6 +430,12 @@ current content and the new entry.
 - `v-prefix`
 
 This presets simply prepends `v` to the version.
+
+### `updateVersion`
+
+- `npm`
+
+This presets updates the `version` property of `$CWD/package.json`.
 
 Support
 -------

--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ When this option is enabled, your project's `CHANGELOG` file, as specified in
 
 If this option is disabled, the generated entry is printed to `stdout`.
 
+### `editVersion (Boolean)`
+
+*Defaults to `true`.*
+
+When this option is enabled, the project's version will be edited as specified
+in the `updateVersion` hook.
+
 ### `parseFooterTags (Boolean)`
 
 *Defaults to `true`.*

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -99,6 +99,11 @@ const CONFIGURATION = {
     default: 'prepend',
     allowsPresets: true
   },
+  updateVersion: {
+    type: 'function',
+    default: 'npm',
+    allowsPresets: true
+  },
   template: {
     type: 'string',
     default: [
@@ -250,10 +255,17 @@ async.waterfall([
     });
 
     if (argv.config.editChangelog) {
-      argv.config.addEntryToChangelog(argv.config.changelogFile, entry, callback);
+      argv.config.addEntryToChangelog(argv.config.changelogFile, entry, (error) => {
+        return callback(error, version);
+      });
     } else {
       console.log(entry);
+      return callback(null, version);
     }
+  },
+
+  (version, callback) => {
+    argv.config.updateVersion(process.cwd(), version, callback);
   }
 
 ], (error) => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -60,6 +60,10 @@ const CONFIGURATION = {
     type: 'boolean',
     default: true
   },
+  editVersion: {
+    type: 'boolean',
+    default: true
+  },
   subjectParser: {
     type: 'function',
     default: _.identity,
@@ -265,7 +269,11 @@ async.waterfall([
   },
 
   (version, callback) => {
-    argv.config.updateVersion(process.cwd(), version, callback);
+    if (argv.config.editVersion) {
+      argv.config.updateVersion(process.cwd(), version, callback);
+    } else {
+      return callback();
+    }
   }
 
 ], (error) => {

--- a/lib/presets.js
+++ b/lib/presets.js
@@ -23,6 +23,8 @@
 const _ = require('lodash');
 const async = require('async');
 const touch = require('touch');
+const path = require('path');
+const updateJSON = require('update-json');
 const fs = require('fs');
 const semver = require('semver');
 const markdown = require('./markdown');
@@ -220,6 +222,46 @@ module.exports = {
       }
 
       return `v${version}`;
+    }
+
+  },
+
+  updateVersion: {
+
+    /**
+     * @summary Update NPM version
+     * @function
+     * @public
+     *
+     * @param {String} cwd - current working directory
+     * @param {String} version - version
+     * @param {Function} callback - callback (error)
+     * @returns {null}
+     *
+     * @example
+     * presets.updateVersion.npm(process.cwd(), '1.0.0', (error) => {
+     *   if (error) {
+     *     throw error;
+     *   }
+     * });
+     */
+    npm: (cwd, version, callback) => {
+      const packageJSON = path.join(cwd, 'package.json');
+      const cleanedVersion = semver.clean(version);
+
+      if (!cleanedVersion) {
+        return callback(new Error(`Invalid version: ${version}`));
+      }
+
+      updateJSON(packageJSON, {
+        version: cleanedVersion
+      }, (error) => {
+        if (error && error.code === 'ENOENT') {
+          error.message = `No such file or directory: ${packageJSON}`;
+        }
+
+        return callback(error);
+      });
     }
 
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "markdown": "^0.5.0",
     "semver": "^5.2.0",
     "touch": "^1.0.0",
+    "update-json": "^1.0.0",
     "yargs": "^4.7.1"
   }
 }

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -4,6 +4,8 @@ module.exports = {
 
   getGitReferenceFromVersion: 'v-prefix',
 
+  updateVersion: 'npm',
+
   includeCommitWhen: (commit) => {
     return commit.footer['Changelog-Entry'];
   },


### PR DESCRIPTION
- `updateVersion`

This option hook would be used to automatically increment the version in
the current project. It ships with a default `npm` preset which updates
`package.json`.

- `editVersion`

This option is used to control whether the project version will be edited
by using the `updateVersion` hook.