### PR TITLE
docs: update README example to showcase new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ npm install -g versionist
 ```
 $ git clone https://github.com/resin-io/versionist
 $ cd versionist
+$ git checkout example
 ```
 
 - Run Versionist
@@ -46,13 +47,8 @@ $ versionist
 
 ***
 
-```
-## 1.1.0 - 2016-07-08
-
-- Add a simple default template.
-- Fix `stdout maxBuffer exceeded` when parsing big logs.
-- Support commits with indented bodies.
-```
+The `CHANGELOG.md` will have a new `2.0.0` entry with the latest changes, and
+the `package.json` version will be updated to `2.0.0`.
 
 Installation
 ------------


### PR DESCRIPTION
Recent commits introduced plenty features, like automatic `CHANGELOG`
and `package.json` editing.

The example from the `README.md` was updated to showcase this feature.

In order to make sure there are always enough changes to get something
generated, we added an `example` annotated tag and instruct the user to
`checkout` it.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>