### PR TITLE
feat: implement addEntryToChangelog `prepend` `fromLine` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
 ## 1.1.0 - 2016-07-08
 
 - Add a simple default template.

--- a/README.md
+++ b/README.md
@@ -458,6 +458,10 @@ This presets prepends the entry to the CHANGELOG file specified in
 `changelogFile`, taking care of not adding unnecessary blank lines between the
 current content and the new entry.
 
+**Options**
+
+- `(Number) fromLine`: Prepend from a certain line.
+
 ### `getGitReferenceFromVersion`
 
 - `v-prefix`

--- a/lib/presets.js
+++ b/lib/presets.js
@@ -165,6 +165,7 @@ module.exports = {
      * @public
      *
      * @param {Object} options - options
+     * @param {Number} [options.fromLine=0] - prepend from line
      * @param {String} file - changelog file path
      * @param {String} entry - changelog entry
      * @param {Function} callback - callback
@@ -177,6 +178,10 @@ module.exports = {
      * });
      */
     prepend: (options, file, entry, callback) => {
+      _.defaults(options, {
+        fromLine: 0
+      });
+
       async.waterfall([
         _.partial(touch, file, {}),
 
@@ -187,16 +192,22 @@ module.exports = {
         },
 
         (contents, done) => {
-          const entryWithoutTrailingSpace = entry.replace(/(\n)+$/, '');
-          const changelogWithoutLeadingSpace = contents.replace(/^(\n)+/, '');
+          const changelogLines = _.split(contents, '\n');
 
-          return done(null, _.attempt(() => {
-            if (_.isEmpty(changelogWithoutLeadingSpace)) {
-              return entryWithoutTrailingSpace;
+          return done(null, _.join(_.reduce([
+            _.slice(changelogLines, 0, options.fromLine),
+            _.split(entry, '\n'),
+            _.slice(changelogLines, options.fromLine)
+          ], (accumulator, array) => {
+            const head = _.dropRightWhile(accumulator, _.isEmpty);
+            const body = _.dropWhile(array, _.isEmpty);
+
+            if (_.isEmpty(head)) {
+              return body;
             }
 
-            return entryWithoutTrailingSpace + '\n\n' + changelogWithoutLeadingSpace;
-          }));
+            return _.concat(head, [ '' ], body);
+          }, []), '\n'));
         },
 
         _.partial(fs.writeFile, file)

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -380,7 +380,8 @@ describe('Presets', function() {
             });
 
             m.chai.expect(contents).to.equal([
-              'Lorem ipsum'
+              'Lorem ipsum',
+              ''
             ].join('\n'));
 
             done();
@@ -539,6 +540,49 @@ describe('Presets', function() {
             done();
           });
 
+        });
+
+      });
+
+      describe('given a temporary file with a header', function() {
+
+        beforeEach(function() {
+          this.tmp = tmp.fileSync();
+          fs.writeFileSync(this.tmp.fd, [
+            'This is my CHANGELOG',
+            '====================',
+            '',
+            'Entry 1'
+          ].join('\n'));
+        });
+
+        afterEach(function() {
+          this.tmp.removeCallback();
+        });
+
+        it('should support a `fromLine` option', function(done) {
+          presets.addEntryToChangelog.prepend({
+            fromLine: 3
+          }, this.tmp.name, [
+            'Entry 2'
+          ].join('\n'), (error) => {
+            m.chai.expect(error).to.not.exist;
+
+            const contents = fs.readFileSync(this.tmp.name, {
+              encoding: 'utf8'
+            });
+
+            m.chai.expect(contents).to.equal([
+              'This is my CHANGELOG',
+              '====================',
+              '',
+              'Entry 2',
+              '',
+              'Entry 1'
+            ].join('\n'));
+
+            done();
+          });
         });
 
       });

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -4,6 +4,11 @@ module.exports = {
 
   getGitReferenceFromVersion: 'v-prefix',
 
+  addEntryToChangelog: {
+    preset: 'prepend',
+    fromLine: 5
+  },
+
   updateVersion: 'npm',
 
   includeCommitWhen: (commit) => {


### PR DESCRIPTION
The CHANGELOG header was removed in 62c4da9 for simplicity purposes,
given we didn't have an easy way to deal with it on
`addEntryToChangelog` `prepend` preset.

This PR implements a `fromLine` option to the `prepend` preset, which as
the name implies, causes the prepending to happen from a certain line.

Now that we have this feature, we restore the original CHANGELOG header
and make use of `fromLine` in our `versionist.conf.js`.

Change-Type: minor
Changelog-Entry: Implement `fromLine` option for `addEntryToChangelog`'s `prepend` preset.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>