### PR TITLE
fix: make sure every exception is nicely displayed

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -300,3 +300,5 @@ async.waterfall([
 
   console.log('Done');
 });
+
+process.on('uncaughtException', showErrorAndQuit);


### PR DESCRIPTION
This module mixes a lot of synchronous and asynchronous code. To make
sure every single exception is caught gets nicely displayed in the CLI
tool, we listen to the `uncaughtException` `process` event.

Change-Type: patch
Changelog-Entry: Make sure every exception is nicely displayed.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>