### PR TITLE
feat: add `transformTemplateData` option hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ module.exports = {
 };
 ```
 
+If you need further manipulation to the data passed to the template that is not
+possible by using template helpers, consider declaring the
+`transformTemplateData` hook.
+
 ### `changelogFile (String)`
 
 *Defaults to `CHANGELOG.md`.*
@@ -281,6 +285,31 @@ module.exports = {
 
 The whole commit object, after any transformations applied by `subjectParser`
 and `bodyParser` is passed as an argument.
+
+### `transformTemplateData (Function)`
+
+*Defaults to the identity function.*
+
+You can declare this function to perform advanced transformations to the data
+that is passed to template in a more granular way.
+
+```js
+module.exports = {
+  ...
+
+  transformTemplateData (data) => {
+    data.commits = // edit commits;
+    data.version = // edit version;
+    data.date = // edit date;
+
+    data.mynewfield = 'foo';
+
+    return data;
+  }
+
+  ...
+};
+```
 
 ### `addEntryToChangelog (Function)`
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -79,6 +79,11 @@ const CONFIGURATION = {
     default: _.constant(true),
     allowsPresets: true
   },
+  transformTemplateData: {
+    type: 'function',
+    default: _.identity,
+    allowsPresets: true
+  },
   includeMergeCommits: {
     type: 'boolean',
     default: false
@@ -272,6 +277,7 @@ async.waterfall([
     const entry = versionist.generateChangelog(history, {
       template: argv.config.template,
       includeCommitWhen: argv.config.includeCommitWhen,
+      transformTemplateData: argv.config.transformTemplateData,
       version: version
     });
 

--- a/lib/versionist.js
+++ b/lib/versionist.js
@@ -166,6 +166,7 @@ exports.calculateNextVersion = (commits, options = {}) => {
  * @param {Object} options - options
  * @param {String} options.version - current semver version
  * @param {Function} [options.includeCommitWhen] - include commit filter predicate
+ * @param {Function} [options.transformTemplateData] - transform template data
  * @param {Date} [options.date=new Date()] - date object
  * @returns {String} CHANGELOG
  *
@@ -201,16 +202,19 @@ exports.generateChangelog = (commits, options = {}) => {
 
   _.defaults(options, {
     date: new Date(),
-    includeCommitWhen: _.constant(true)
+    includeCommitWhen: _.constant(true),
+    transformTemplateData: _.identity
   });
 
   if (!(options.date instanceof Date)) {
     throw new Error(`Invalid date option: ${options.date}`);
   }
 
-  return template.render(options.template, {
+  const templateData = options.transformTemplateData({
     commits: _.filter(commits, options.includeCommitWhen),
     version: semver.normalize(options.version),
     date: options.date
   });
+
+  return template.render(options.template, templateData);
 };

--- a/tests/versionist.spec.js
+++ b/tests/versionist.spec.js
@@ -364,6 +364,42 @@ describe('Versionist', function() {
       ].join('\n'));
     });
 
+    it('should support a transformTemplateData option', function() {
+      const result = versionist.generateChangelog([
+        {
+          subject: 'foo'
+        },
+        {
+          subject: 'bar'
+        },
+        {
+          subject: 'baz'
+        }
+      ], {
+        version: '1.0.0',
+        transformTemplateData: (data) => {
+          data.commits = _.map(data.commits, 'subject');
+          data.version = 'v' + data.version;
+          return data;
+        },
+        date: new Date(),
+        template: [
+          'Version: {{version}}',
+          '{{#each commits}}',
+          '{{this}}',
+          '{{/each}}'
+        ].join('\n')
+      });
+
+      m.chai.expect(result).to.equal([
+        'Version: v1.0.0',
+        'foo',
+        'bar',
+        'baz',
+        ''
+      ].join('\n'));
+    });
+
   });
 
 });


### PR DESCRIPTION
This hook is useful to perform more advanced manipulations to the data
that is passed to the template. Can be useful in certain situations.

Change-Type: minor
Changelog-Entry: Add `transformTemplateData` option hook.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>