### PR TITLE
fix: uncaught exception if current version is omitted

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -266,7 +266,7 @@ async.waterfall([
 
     if (_.includes(documentedVersions, version)) {
       console.log(`Omitting: ${version}`);
-      return callback();
+      return callback(null, null);
     }
 
     const entry = versionist.generateChangelog(history, {


### PR DESCRIPTION
The callbacks in this waterfall entry all yield a version. When omitting
the version, we call `callback` without parameters, therefore the next
waterfall entry passes the new callback as the first parameter, causing
a confusing error to be thrown.

In order to be consistent with other callback calls, we manually pass a
`null` version as the second argument.

Change-Type: patch
Changelog-Entry: Fix uncaught exception if current version is omitted.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>