### PR TITLE
feat: add `incrementVersion` option hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,15 @@ has been made), and should return either `major`, `minor` or `patch`.
 If the increment level returned from this function is not defined, the commit
 will not alter the final version.
 
+### `incrementVersion (Function)`
+
+*Defaults to `semver`.*
+
+Declare this function to customise how an increment level is used to increment
+the current version.
+
+This function takes the current version and the increment level as arguments.
+
 ### `getGitReferenceFromVersion (Function)`
 
 *Defaults to the identity function.*
@@ -502,6 +511,12 @@ This presets simply prepends `v` to the version.
 - `npm`
 
 This presets updates the `version` property of `$CWD/package.json`.
+
+### `incrementVersion`
+
+- `semver`
+
+This preset increments the version according to semver rules.
 
 Support
 -------

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -98,6 +98,11 @@ const CONFIGURATION = {
     default: _.constant(null),
     allowsPresets: true
   },
+  incrementVersion: {
+    type: 'function',
+    default: 'semver',
+    allowsPresets: true
+  },
   getGitReferenceFromVersion: {
     type: 'function',
     default: _.identity,
@@ -266,7 +271,8 @@ async.waterfall([
   (documentedVersions, history, callback) => {
     const version = versionist.calculateNextVersion(history, {
       getIncrementLevelFromCommit: argv.config.getIncrementLevelFromCommit,
-      currentVersion: argv.current || semver.getGreaterVersion(documentedVersions)
+      currentVersion: argv.current || semver.getGreaterVersion(documentedVersions),
+      incrementVersion: argv.config.incrementVersion
     });
 
     if (_.includes(documentedVersions, version)) {

--- a/lib/presets.js
+++ b/lib/presets.js
@@ -281,6 +281,38 @@ module.exports = {
       });
     }
 
+  },
+
+  incrementVersion: {
+
+    /**
+     * @summary Increment a version following semver
+     * @function
+     * @public
+     *
+     * @param {String} version - original version
+     * @param {String} incrementLevel - increment level
+     * @returns {String} incremented version
+     *
+     * @example
+     * const version = presets.incrementVersion.semver('1.0.0', 'major');
+     * console.log(version);
+     * > 2.0.0
+     */
+    semver: (version, incrementLevel) => {
+      if (!semver.valid(version)) {
+        throw new Error(`Invalid version: ${version}`);
+      }
+
+      const incrementedVersion = semver.inc(version, incrementLevel);
+
+      if (!incrementedVersion) {
+        throw new Error(`Invalid increment level: ${incrementLevel}`);
+      }
+
+      return incrementedVersion;
+    }
+
   }
 
 };

--- a/lib/semver.js
+++ b/lib/semver.js
@@ -161,32 +161,6 @@ exports.normalize = (version) => {
 };
 
 /**
- * @summary Increment a version following semver
- * @function
- * @public
- *
- * @param {String} version - original version
- * @param {String} incrementLevel - increment level
- * @returns {String} incremented version
- *
- * @example
- * const version = semver.incrementVersion('1.0.0', 'major');
- * console.log(version);
- * > 2.0.0
- */
-exports.incrementVersion = (version, incrementLevel) => {
-  if (!exports.isValidIncrementLevel(incrementLevel)) {
-    throw new Error(`Invalid increment level: ${incrementLevel}`);
-  }
-
-  if (!semver.valid(version)) {
-    throw new Error(`Invalid version: ${version}`);
-  }
-
-  return semver.inc(version, incrementLevel);
-};
-
-/**
  * @summary Get greater semantic version
  * @function
  * @public

--- a/lib/versionist.js
+++ b/lib/versionist.js
@@ -116,9 +116,12 @@ exports.readCommitHistory = (gitDirectory, options = {}, callback) => {
  * @param {Object} options - options
  * @param {String} options.currentVersion - current semver version
  * @param {Function} options.getIncrementLevelFromCommit - get increment level from commit
+ * @param {Function} options.incrementVersion - increment version function
  * @returns {String} next version
  *
  * @example
+ * const semver = require('semver');
+ *
  * const nextVersion = versionist.calculateNextVersion([
  *   {
  *     subject: 'foo bar',
@@ -127,6 +130,7 @@ exports.readCommitHistory = (gitDirectory, options = {}, callback) => {
  *   ...
  * ], {
  *   currentVersion: '1.1.0',
+ *   incrementVersion: semver.inc,
  *   getIncrementLevelFromCommit: (commit) => {
  *     // Return a valid increment level from the commit
  *   }
@@ -146,6 +150,14 @@ exports.calculateNextVersion = (commits, options = {}) => {
     throw new Error(`Invalid getIncrementLevelFromCommit option: ${options.getIncrementLevelFromCommit}`);
   }
 
+  if (!options.incrementVersion) {
+    throw new Error('Missing the incrementVersion option');
+  }
+
+  if (!_.isFunction(options.incrementVersion)) {
+    throw new Error(`Invalid incrementVersion option: ${options.incrementVersion}`);
+  }
+
   const incrementLevel = semver.calculateNextIncrementLevel(commits, {
     getIncrementLevelFromCommit: options.getIncrementLevelFromCommit
   });
@@ -154,7 +166,7 @@ exports.calculateNextVersion = (commits, options = {}) => {
     return options.currentVersion;
   }
 
-  return semver.incrementVersion(options.currentVersion, incrementLevel);
+  return options.incrementVersion(options.currentVersion, incrementLevel);
 };
 
 /**

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -717,4 +717,43 @@ describe('Presets', function() {
 
   });
 
+  describe('.incrementVersion', function() {
+
+    describe('.semver', function() {
+
+      it('should throw if the increment level is not valid', function() {
+        m.chai.expect(() => {
+          presets.incrementVersion.semver('1.0.0', 'foo');
+        }).to.throw('Invalid increment level: foo');
+      });
+
+      it('should throw if the version is not valid', function() {
+        m.chai.expect(() => {
+          presets.incrementVersion.semver('hello', 'major');
+        }).to.throw('Invalid version: hello');
+      });
+
+      it('should discard a `v` prefix in the original version', function() {
+        const version = presets.incrementVersion.semver('v1.0.0', 'major');
+        m.chai.expect(version).to.equal('2.0.0');
+      });
+
+      it('should be able to increment a major level', function() {
+        const version = presets.incrementVersion.semver('1.0.0', 'major');
+        m.chai.expect(version).to.equal('2.0.0');
+      });
+
+      it('should be able to increment a minor level', function() {
+        const version = presets.incrementVersion.semver('1.0.0', 'minor');
+        m.chai.expect(version).to.equal('1.1.0');
+      });
+
+      it('should be able to increment a patch level', function() {
+        const version = presets.incrementVersion.semver('1.0.0', 'patch');
+        m.chai.expect(version).to.equal('1.0.1');
+      });
+
+    });
+
+  });
 });

--- a/tests/semver.spec.js
+++ b/tests/semver.spec.js
@@ -256,42 +256,6 @@ describe('Semver', function() {
 
   });
 
-  describe('.incrementVersion()', function() {
-
-    it('should throw if the increment level is not valid', function() {
-      m.chai.expect(() => {
-        semver.incrementVersion('1.0.0', 'foo');
-      }).to.throw('Invalid increment level: foo');
-    });
-
-    it('should throw if the version is not valid', function() {
-      m.chai.expect(() => {
-        semver.incrementVersion('hello', 'major');
-      }).to.throw('Invalid version: hello');
-    });
-
-    it('should discard a `v` prefix in the original version', function() {
-      const version = semver.incrementVersion('v1.0.0', 'major');
-      m.chai.expect(version).to.equal('2.0.0');
-    });
-
-    it('should be able to increment a major level', function() {
-      const version = semver.incrementVersion('1.0.0', 'major');
-      m.chai.expect(version).to.equal('2.0.0');
-    });
-
-    it('should be able to increment a minor level', function() {
-      const version = semver.incrementVersion('1.0.0', 'minor');
-      m.chai.expect(version).to.equal('1.1.0');
-    });
-
-    it('should be able to increment a patch level', function() {
-      const version = semver.incrementVersion('1.0.0', 'patch');
-      m.chai.expect(version).to.equal('1.0.1');
-    });
-
-  });
-
   describe('.getGreaterVersion()', function() {
 
     it('should throw if there is an invalid version', function() {

--- a/tests/versionist.spec.js
+++ b/tests/versionist.spec.js
@@ -20,6 +20,7 @@ const m = require('mochainon');
 const _ = require('lodash');
 const childProcess = require('child_process');
 const versionist = require('../lib/versionist');
+const presets = require('../lib/presets');
 const utils = require('./utils');
 
 describe('Versionist', function() {
@@ -167,6 +168,7 @@ describe('Versionist', function() {
       m.chai.expect(() => {
         versionist.calculateNextVersion(null, {
           currentVersion: '1.0.0',
+          incrementVersion: presets.incrementVersion.semver,
           getIncrementLevelFromCommit: (commit) => {
             return _.first(_.split(commit.subject, ' '));
           }
@@ -181,6 +183,7 @@ describe('Versionist', function() {
             subject: 'major foo bar'
           }
         ], {
+          incrementVersion: presets.incrementVersion.semver,
           getIncrementLevelFromCommit: (commit) => {
             return _.first(_.split(commit.subject, ' '));
           }
@@ -196,6 +199,7 @@ describe('Versionist', function() {
           }
         ], {
           currentVersion: 'hello',
+          incrementVersion: presets.incrementVersion.semver,
           getIncrementLevelFromCommit: (commit) => {
             return _.first(_.split(commit.subject, ' '));
           }
@@ -210,6 +214,7 @@ describe('Versionist', function() {
             subject: 'major foo bar'
           }
         ], {
+          incrementVersion: presets.incrementVersion.semver,
           currentVersion: '1.0.0'
         });
       }).to.throw('Missing the getIncrementLevelFromCommit option');
@@ -223,9 +228,37 @@ describe('Versionist', function() {
           }
         ], {
           currentVersion: '1.0.0',
+          incrementVersion: presets.incrementVersion.semver,
           getIncrementLevelFromCommit: 'foo'
         });
       }).to.throw('Invalid getIncrementLevelFromCommit option: foo');
+    });
+
+    it('should throw if options.incrementVersion is missing', function() {
+      m.chai.expect(() => {
+        versionist.calculateNextVersion([
+          {
+            subject: 'major foo bar'
+          }
+        ], {
+          currentVersion: '1.0.0',
+          getIncrementLevelFromCommit: _.constant(null)
+        });
+      }).to.throw('Missing the incrementVersion option');
+    });
+
+    it('should throw if options.incrementVersion is not a function', function() {
+      m.chai.expect(() => {
+        versionist.calculateNextVersion([
+          {
+            subject: 'major foo bar'
+          }
+        ], {
+          currentVersion: '1.0.0',
+          incrementVersion: 'foo',
+          getIncrementLevelFromCommit: _.constant(null)
+        });
+      }).to.throw('Invalid incrementVersion option: foo');
     });
 
     it('should return options.currentVersion if no increment level was found', function() {
@@ -238,6 +271,7 @@ describe('Versionist', function() {
         }
       ], {
         currentVersion: '1.0.0',
+        incrementVersion: presets.incrementVersion.semver,
         getIncrementLevelFromCommit: _.constant(null)
       });
 
@@ -248,9 +282,26 @@ describe('Versionist', function() {
       m.chai.expect(() => {
         versionist.calculateNextVersion([], {
           currentVersion: '1.0.0',
+          incrementVersion: presets.incrementVersion.semver,
           getIncrementLevelFromCommit: _.constant(null)
         });
       }).to.throw('No commits to calculate the next increment level from');
+    });
+
+    it('should calculate the next version', function() {
+      const nextVersion = versionist.calculateNextVersion([
+        {
+          subject: 'major foo bar'
+        }
+      ], {
+        currentVersion: '1.0.0',
+        incrementVersion: presets.incrementVersion.semver,
+        getIncrementLevelFromCommit: (commit) => {
+          return _.first(_.split(commit.subject, ' '));
+        }
+      });
+
+      m.chai.expect(nextVersion).to.equal('2.0.0');
     });
 
   });


### PR DESCRIPTION
This hook can be declared to customise how a version is incremented
given an increment level. It can be handy in some edge cases, and
defaults to incrementing a version based on semver rules.

Change-Type: minor
Changelog-Entry: Add `incrementVersion` option hook.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>