### PR TITLE
feat: add `defaultInitialVersion` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ possible by using template helpers, consider declaring the
 This option specifies the desired location of your `CHANGELOG` file, relative
 to the root of your project.
 
+### `defaultInitialVersion (String)`
+
+*Defaults to `0.0.1`.*
+
+This option specifies the desired default initial version, in case the
+`getChangelogDocumentedVersions` hook doesn't find any.
+
 ### `editChangelog (Boolean)`
 
 *Defaults to `true`.*


### PR DESCRIPTION
This option, which defaults to `0.0.1`, can be used to configure the
desired default initial version in case the
`getChangelogDocumentedVersions` hook doesn't find any version.

If the default version reference can't be found on git, then all commits
from the beginning of the project will be included in such version.

Change-Type: minor
Changelog-Entry: Add `defaultInitialVersion` option.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>