### PR TITLE
fix: `changelog-headers` ENOENT when no changelog file

### DIFF
--- a/lib/presets.js
+++ b/lib/presets.js
@@ -140,6 +140,10 @@ module.exports = {
         encoding: 'utf8'
       }, (error, changelog) => {
         if (error) {
+          if (error.code === 'ENOENT') {
+            return callback(null, []);
+          }
+
           return callback(error);
         }
 

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -243,6 +243,30 @@ describe('Presets', function() {
 
       });
 
+      describe('given the file does not exist', function() {
+
+        beforeEach(function() {
+          this.fsReadFileStub = m.sinon.stub(fs, 'readFile');
+          const ENOENT = new Error('ENOENT');
+          ENOENT.code = 'ENOENT';
+          this.fsReadFileStub.yields(ENOENT);
+        });
+
+        afterEach(function() {
+          this.fsReadFileStub.restore();
+        });
+
+        it('should yield back an empty array', function(done) {
+          const fn = presets.getChangelogDocumentedVersions['changelog-headers'];
+          fn({}, 'CHANGELOG.md', (error, versions) => {
+            m.chai.expect(error).to.not.exist;
+            m.chai.expect(versions).to.deep.equal([]);
+            done();
+          });
+        });
+
+      });
+
       describe('given the file contained versions as headers', function() {
 
         beforeEach(function() {


### PR DESCRIPTION
Currently, the `.getChangelogDocumentedVersions()` `changelog-headers`
preset throws an `ENOENT` error if a CHANGELOG file doesn't yet exist.

This causes confusions for users configuring Versionist on their
projects right at the beginning.

A better behaviour is to yield an empty array.

Change-Type: patch
Changelog-Entry: Don't throw ENOENT in `changelog-headers` preset if the changelog file doesn't exist.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>