### PR TITLE
minifix: invalid version when using `semver` `incrementVersion` preset

### DIFF
--- a/lib/presets.js
+++ b/lib/presets.js
@@ -294,16 +294,17 @@ module.exports = {
      * @function
      * @public
      *
+     * @param {Object} options - options
      * @param {String} version - original version
      * @param {String} incrementLevel - increment level
      * @returns {String} incremented version
      *
      * @example
-     * const version = presets.incrementVersion.semver('1.0.0', 'major');
+     * const version = presets.incrementVersion.semver({}, '1.0.0', 'major');
      * console.log(version);
      * > 2.0.0
      */
-    semver: (version, incrementLevel) => {
+    semver: (options, version, incrementLevel) => {
       if (!semver.valid(version)) {
         throw new Error(`Invalid version: ${version}`);
       }

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -747,33 +747,33 @@ describe('Presets', function() {
 
       it('should throw if the increment level is not valid', function() {
         m.chai.expect(() => {
-          presets.incrementVersion.semver('1.0.0', 'foo');
+          presets.incrementVersion.semver({}, '1.0.0', 'foo');
         }).to.throw('Invalid increment level: foo');
       });
 
       it('should throw if the version is not valid', function() {
         m.chai.expect(() => {
-          presets.incrementVersion.semver('hello', 'major');
+          presets.incrementVersion.semver({}, 'hello', 'major');
         }).to.throw('Invalid version: hello');
       });
 
       it('should discard a `v` prefix in the original version', function() {
-        const version = presets.incrementVersion.semver('v1.0.0', 'major');
+        const version = presets.incrementVersion.semver({}, 'v1.0.0', 'major');
         m.chai.expect(version).to.equal('2.0.0');
       });
 
       it('should be able to increment a major level', function() {
-        const version = presets.incrementVersion.semver('1.0.0', 'major');
+        const version = presets.incrementVersion.semver({}, '1.0.0', 'major');
         m.chai.expect(version).to.equal('2.0.0');
       });
 
       it('should be able to increment a minor level', function() {
-        const version = presets.incrementVersion.semver('1.0.0', 'minor');
+        const version = presets.incrementVersion.semver({}, '1.0.0', 'minor');
         m.chai.expect(version).to.equal('1.1.0');
       });
 
       it('should be able to increment a patch level', function() {
-        const version = presets.incrementVersion.semver('1.0.0', 'patch');
+        const version = presets.incrementVersion.semver({}, '1.0.0', 'patch');
         m.chai.expect(version).to.equal('1.0.1');
       });
 

--- a/tests/versionist.spec.js
+++ b/tests/versionist.spec.js
@@ -168,7 +168,7 @@ describe('Versionist', function() {
       m.chai.expect(() => {
         versionist.calculateNextVersion(null, {
           currentVersion: '1.0.0',
-          incrementVersion: presets.incrementVersion.semver,
+          incrementVersion: _.partial(presets.incrementVersion.semver, {}),
           getIncrementLevelFromCommit: (commit) => {
             return _.first(_.split(commit.subject, ' '));
           }
@@ -183,7 +183,7 @@ describe('Versionist', function() {
             subject: 'major foo bar'
           }
         ], {
-          incrementVersion: presets.incrementVersion.semver,
+          incrementVersion: _.partial(presets.incrementVersion.semver, {}),
           getIncrementLevelFromCommit: (commit) => {
             return _.first(_.split(commit.subject, ' '));
           }
@@ -199,7 +199,7 @@ describe('Versionist', function() {
           }
         ], {
           currentVersion: 'hello',
-          incrementVersion: presets.incrementVersion.semver,
+          incrementVersion: _.partial(presets.incrementVersion.semver, {}),
           getIncrementLevelFromCommit: (commit) => {
             return _.first(_.split(commit.subject, ' '));
           }
@@ -214,7 +214,7 @@ describe('Versionist', function() {
             subject: 'major foo bar'
           }
         ], {
-          incrementVersion: presets.incrementVersion.semver,
+          incrementVersion: _.partial(presets.incrementVersion.semver, {}),
           currentVersion: '1.0.0'
         });
       }).to.throw('Missing the getIncrementLevelFromCommit option');
@@ -228,7 +228,7 @@ describe('Versionist', function() {
           }
         ], {
           currentVersion: '1.0.0',
-          incrementVersion: presets.incrementVersion.semver,
+          incrementVersion: _.partial(presets.incrementVersion.semver, {}),
           getIncrementLevelFromCommit: 'foo'
         });
       }).to.throw('Invalid getIncrementLevelFromCommit option: foo');
@@ -271,7 +271,7 @@ describe('Versionist', function() {
         }
       ], {
         currentVersion: '1.0.0',
-        incrementVersion: presets.incrementVersion.semver,
+        incrementVersion: _.partial(presets.incrementVersion.semver, {}),
         getIncrementLevelFromCommit: _.constant(null)
       });
 
@@ -282,7 +282,7 @@ describe('Versionist', function() {
       m.chai.expect(() => {
         versionist.calculateNextVersion([], {
           currentVersion: '1.0.0',
-          incrementVersion: presets.incrementVersion.semver,
+          incrementVersion: _.partial(presets.incrementVersion.semver, {}),
           getIncrementLevelFromCommit: _.constant(null)
         });
       }).to.throw('No commits to calculate the next increment level from');
@@ -295,7 +295,7 @@ describe('Versionist', function() {
         }
       ], {
         currentVersion: '1.0.0',
-        incrementVersion: presets.incrementVersion.semver,
+        incrementVersion: _.partial(presets.incrementVersion.semver, {}),
         getIncrementLevelFromCommit: (commit) => {
           return _.first(_.split(commit.subject, ' '));
         }


### PR DESCRIPTION
Presets should take an option object as the first argument. Such object
is automatically partially applied by the CLI when reading the
configuration file.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>