### PR TITLE
test: create a basic CLI end to end test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ bower_components
 *.cer
 *.crt
 *.pem
+
+# Temporal CLI test data
+tests/cli/temporal

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "versionist": "./bin/cli.js"
   },
   "scripts": {
-    "test": "npm run lint && mocha --recursive tests -R spec",
+    "test": "npm run lint && mocha tests -R spec && node tests/cli/run",
     "lint": "eslint lib tests bin"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
@@ -23,6 +23,7 @@
     "indent-string": "^3.0.0",
     "mocha": "^2.5.3",
     "mochainon": "^1.0.0",
+    "shelljs": "^0.7.3",
     "tmp": "0.0.28"
   },
   "dependencies": {

--- a/tests/cli/cases/no-changelog.js
+++ b/tests/cli/cases/no-changelog.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const shelljs = require('shelljs');
+const utils = require('../utils');
+const TEST_DIRECTORY = utils.getTestTemporalPathFromFilename(__filename);
+
+shelljs.rm('-rf', TEST_DIRECTORY);
+shelljs.mkdir('-p', TEST_DIRECTORY);
+shelljs.cd(TEST_DIRECTORY);
+
+utils.createVersionistConfiguration([
+  '\'use strict\';',
+  'module.exports = {',
+  '  subjectParser: \'angular\',',
+  '  editVersion: false,',
+  '  addEntryToChangelog: \'prepend\',',
+  '  includeCommitWhen: (commit) => {',
+  '    return commit.footer[\'Changelog-Entry\'];',
+  '  },',
+  '  getIncrementLevelFromCommit: (commit) => {',
+  '    return commit.footer[\'Change-Type\'];',
+  '  },',
+  '  template: [',
+  '    \'## {{version}}\',',
+  '    \'\',',
+  '    \'{{#each commits}}\',',
+  '    \'{{#with footer}}\',',
+  '    \'- {{capitalize Changelog-Entry}}\',',
+  '    \'{{/with}}\',',
+  '    \'{{/each}}\'',
+  '  ].join(\'\\n\')',
+  '};',
+  ''
+].join('\n'));
+
+shelljs.exec('git init');
+
+utils.createCommit('feat: implement x', {
+  'Changelog-Entry': 'Implement x',
+  'Change-Type': 'minor'
+});
+
+utils.createCommit('fix: fix y', {
+  'Changelog-Entry': 'Fix y',
+  'Change-Type': 'patch'
+});
+
+utils.createCommit('fix: fix z', {
+  'Changelog-Entry': 'Fix z',
+  'Change-Type': 'patch'
+});
+
+utils.callVersionist();
+
+m.chai.expect(shelljs.cat('CHANGELOG.md').stdout).to.deep.equal([
+  '## 0.1.0',
+  '',
+  '- Fix z',
+  '- Fix y',
+  '- Implement x',
+  ''
+].join('\n'));

--- a/tests/cli/run.js
+++ b/tests/cli/run.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const shelljs = require('shelljs');
+
+_.each(fs.readdirSync(path.join(__dirname, 'cases')), (file) => {
+  shelljs.exec(`node ${path.join(__dirname, 'cases', file)}`);
+});

--- a/tests/cli/utils.js
+++ b/tests/cli/utils.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+const shelljs = require('shelljs');
+const path = require('path');
+
+exports.getTestTemporalPathFromFilename = (filename) => {
+  const extension = path.extname(filename);
+  const name = path.basename(filename, extension);
+  return path.join(__dirname, 'temporal', name);
+};
+
+exports.createCommit = (title, tags) => {
+  const footer = _.join(_.map(tags, (value, name) => {
+    return `${name}: ${value}`;
+  }), '\n');
+
+  shelljs.exec(`git commit --allow-empty -m "${title}" -m "${footer}"`);
+};
+
+exports.createVersionistConfiguration = (configuration) => {
+  shelljs.echo(configuration).to('versionist.conf.js');
+};
+
+exports.callVersionist = () => {
+  const cliPath = path.join(__dirname, '..', '..', 'bin', 'cli.js');
+  shelljs.exec(`node ${cliPath}`);
+};


### PR DESCRIPTION
This test suite creates real repositories with real commits and performs
actions on them using the Versionist CLI. This approach will allow us to
run tests on the CLI code, and make sure certain scenarious are free
from regressions

The e2e test suite will run with `npm test` automatically.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>