### PR TITLE
fix: `parseFooterTags` not taking effect

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -298,7 +298,8 @@ async.waterfall([
       startReference: startReference,
       endReference: 'HEAD',
       subjectParser: argv.config.subjectParser,
-      bodyParser: argv.config.bodyParser
+      bodyParser: argv.config.bodyParser,
+      parseFooterTags: argv.config.parseFooterTags
     }, (error, history) => {
       return callback(error, documentedVersions, history);
     });

--- a/lib/versionist.js
+++ b/lib/versionist.js
@@ -43,6 +43,7 @@ const semver = require('./semver');
  * @param {Function} [options.subjectParser] - subject parser hook
  * @param {Function} [options.bodyParser] - body parser hook
  * @param {Boolean} [options.includeMergeCommits=false] - include merge commits
+ * @param {Boolean} [options.parseFooterTags=true] - parse footer tags
  * @param {Function} callback - callback (error, commits)
  *
  * @example
@@ -100,7 +101,8 @@ exports.readCommitHistory = (gitDirectory, options = {}, callback) => {
 
     const parsedCommits = gitLog.parseGitLogYAMLOutput(stdout, {
       subjectParser: options.subjectParser,
-      bodyParser: options.bodyParser
+      bodyParser: options.bodyParser,
+      parseFooterTags: options.parseFooterTags
     });
 
     return callback(null, parsedCommits);

--- a/tests/cli/cases/no-parse-footer-tags.js
+++ b/tests/cli/cases/no-parse-footer-tags.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const shelljs = require('shelljs');
+const utils = require('../utils');
+const TEST_DIRECTORY = utils.getTestTemporalPathFromFilename(__filename);
+
+shelljs.rm('-rf', TEST_DIRECTORY);
+shelljs.mkdir('-p', TEST_DIRECTORY);
+shelljs.cd(TEST_DIRECTORY);
+
+utils.createVersionistConfiguration([
+  '\'use strict\';',
+  'module.exports = {',
+  '  editVersion: false,',
+  '  parseFooterTags: false,',
+  '  addEntryToChangelog: \'prepend\',',
+  '  getIncrementLevelFromCommit: (commit) => {',
+  '    return \'major\';',
+  '  },',
+  '  template: [',
+  '    \'## {{version}}\',',
+  '    \'\',',
+  '    \'{{#each commits}}\',',
+  '    \'- {{this.subject}}\',',
+  '    \'{{this.body}}\',',
+  '    \'\',',
+  '    \'{{/each}}\'',
+  '  ].join(\'\\n\')',
+  '};',
+  ''
+].join('\n'));
+
+shelljs.exec('git init');
+
+utils.createCommit('Implement x', {
+  'My-Tag': 'Foo'
+});
+
+utils.createCommit('Fix y', {
+  'My-Tag': 'Bar'
+});
+
+utils.createCommit('Fix z', {
+  'My-Tag': 'Baz'
+});
+
+utils.callVersionist();
+
+m.chai.expect(shelljs.cat('CHANGELOG.md').stdout).to.deep.equal([
+  '## 1.0.0',
+  '',
+  '- Fix z',
+  'My-Tag: Baz',
+  '',
+  '- Fix y',
+  'My-Tag: Bar',
+  '',
+  '- Implement x',
+  'My-Tag: Foo',
+  ''
+].join('\n'));


### PR DESCRIPTION
The `parseFooterTags` config value was not propagated to
`gitLog.parseGitLogYAMLOutput()` via `versionist.readCommitHistory()`.

Change-Type: patch
Changelog-Entry: Fix `parseFooterTags` not taking effect.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>