### PR TITLE
minifix: make sure CLI tests exit with exit code 1 on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 before_install:
   - npm install -g npm@latest
+before_script:
+  - git config --global user.email "juan@resin.io"
+  - git config --global user.name "Juan Cruz Viotti"
 node_js:
   - "6"
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@
 
 init:
   - git config --global core.autocrlf input
+  - git config --global user.email "juan@resin.io"
+  - git config --global user.name "Juan Cruz Viotti"
 
 cache:
   - C:\Users\appveyor\.node-gyp

--- a/tests/cli/run.js
+++ b/tests/cli/run.js
@@ -22,5 +22,10 @@ const path = require('path');
 const shelljs = require('shelljs');
 
 _.each(fs.readdirSync(path.join(__dirname, 'cases')), (file) => {
-  shelljs.exec(`node ${path.join(__dirname, 'cases', file)}`);
+  const exitCode = shelljs.exec(`node ${path.join(__dirname, 'cases', file)}`).code;
+
+  if (exitCode !== 0) {
+    console.error(`${file} - Test failed with exit code: ${exitCode}`);
+    process.exit(1);
+  }
 });

--- a/tests/cli/utils.js
+++ b/tests/cli/utils.js
@@ -31,7 +31,13 @@ exports.createCommit = (title, tags) => {
     return `${name}: ${value}`;
   }), '\n');
 
-  shelljs.exec(`git commit --allow-empty -m "${title}" -m "${footer}"`);
+  shelljs.echo([
+    title,
+    '',
+    footer
+  ].join('\n')).to('message.txt');
+
+  shelljs.exec('git commit --allow-empty -F message.txt');
 };
 
 exports.createVersionistConfiguration = (configuration) => {


### PR DESCRIPTION
Turns out non-zero exit codes are swallowed by `shelljs.exec`.

Making sure that a non-zero exit code from the CLI test cases halts the
CI builds reveals that the CI services require us to configure `git`
before being able to use it directly to perform a commit.

We also needed to save the git commit message to a temporary file and
re-use it with `-F` on `git commit` given that Windows gets confused by
line breaks in `-m`.

See: http://stackoverflow.com/a/20438380/1641422
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>