### PR TITLE
style: fix lint warning in `no-parse-footer-tags.js` test case

### DIFF
--- a/tests/cli/cases/no-parse-footer-tags.js
+++ b/tests/cli/cases/no-parse-footer-tags.js
@@ -31,7 +31,7 @@ utils.createVersionistConfiguration([
   '  editVersion: false,',
   '  parseFooterTags: false,',
   '  addEntryToChangelog: \'prepend\',',
-  '  getIncrementLevelFromCommit: (commit) => {',
+  '  getIncrementLevelFromCommit: () => {',
   '    return \'major\';',
   '  },',
   '  template: [',


### PR DESCRIPTION
The linter complained that the `commit` parameter was not used in the
function body.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>