### PR TITLE
fix: reject non-existent git refs if there are documented versions

### DIFF
--- a/tests/cli/cases/idempotence.js
+++ b/tests/cli/cases/idempotence.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const shelljs = require('shelljs');
+const utils = require('../utils');
+const TEST_DIRECTORY = utils.getTestTemporalPathFromFilename(__filename);
+
+shelljs.rm('-rf', TEST_DIRECTORY);
+shelljs.mkdir('-p', TEST_DIRECTORY);
+shelljs.cd(TEST_DIRECTORY);
+
+utils.createVersionistConfiguration([
+  '\'use strict\';',
+  'module.exports = {',
+  '  subjectParser: \'angular\',',
+  '  editVersion: false,',
+  '  addEntryToChangelog: \'prepend\',',
+  '  includeCommitWhen: (commit) => {',
+  '    return commit.footer[\'Changelog-Entry\'];',
+  '  },',
+  '  getIncrementLevelFromCommit: (commit) => {',
+  '    return commit.footer[\'Change-Type\'];',
+  '  },',
+  '  template: [',
+  '    \'## {{version}}\',',
+  '    \'\',',
+  '    \'{{#each commits}}\',',
+  '    \'{{#with footer}}\',',
+  '    \'- {{capitalize Changelog-Entry}}\',',
+  '    \'{{/with}}\',',
+  '    \'{{/each}}\'',
+  '  ].join(\'\\n\')',
+  '};',
+  ''
+].join('\n'));
+
+shelljs.exec('git init');
+
+utils.createCommit('feat: implement x', {
+  'Changelog-Entry': 'Implement x',
+  'Change-Type': 'minor'
+});
+
+utils.createCommit('fix: fix y', {
+  'Changelog-Entry': 'Fix y',
+  'Change-Type': 'patch'
+});
+
+utils.createCommit('fix: fix z', {
+  'Changelog-Entry': 'Fix z',
+  'Change-Type': 'patch'
+});
+
+// Call Versionist many times
+utils.callVersionist();
+utils.callVersionist();
+utils.callVersionist();
+utils.callVersionist();
+utils.callVersionist();
+
+m.chai.expect(shelljs.cat('CHANGELOG.md').stdout).to.deep.equal([
+  '## 0.1.0',
+  '',
+  '- Fix z',
+  '- Fix y',
+  '- Implement x',
+  ''
+].join('\n'));


### PR DESCRIPTION
If we repeatedly call Versionist from the beginning of a project, all
the commits so far will be added over and over again.

The reason for this is that we default the start commit for
`versionist.readCommitHistory()` to `null` if a reference is not found,
independently on if it corresponds to the default initial version or
not.

To solve this issue, we only default the start commit to `null` if no
documented version was found on the repository.

Change-Type: patch
Changelog-Entry: Reject non-existent git references if there are documented versions.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>