### PR TITLE
refactor: extract CLI configuration logic to a new module

### DIFF
--- a/lib/cli/configuration.js
+++ b/lib/cli/configuration.js
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * @module Versionist.CLI.Configuration
+ */
+
+const _ = require('lodash');
+const presets = require('../presets');
+
+/**
+ * @summary Configuration default values
+ * @type Object
+ * @constant
+ * @private
+ */
+const DEFAULTS = {
+  path: {
+    type: 'string',
+    default: process.cwd()
+  },
+  changelogFile: {
+    type: 'string',
+    default: 'CHANGELOG.md'
+  },
+  defaultInitialVersion: {
+    type: 'string',
+    default: '0.0.1'
+  },
+  gitDirectory: {
+    type: 'string',
+    default: '.git'
+  },
+  parseFooterTags: {
+    type: 'boolean',
+    default: true
+  },
+  editChangelog: {
+    type: 'boolean',
+    default: true
+  },
+  editVersion: {
+    type: 'boolean',
+    default: true
+  },
+  subjectParser: {
+    type: 'function',
+    default: _.identity,
+    allowsPresets: true
+  },
+  bodyParser: {
+    type: 'function',
+    default: _.identity,
+    allowsPresets: true
+  },
+  includeCommitWhen: {
+    type: 'function',
+    default: _.constant(true),
+    allowsPresets: true
+  },
+  transformTemplateData: {
+    type: 'function',
+    default: _.identity,
+    allowsPresets: true
+  },
+  includeMergeCommits: {
+    type: 'boolean',
+    default: false
+  },
+  getChangelogDocumentedVersions: {
+    type: 'function',
+    default: 'changelog-headers',
+    allowsPresets: true
+  },
+  getIncrementLevelFromCommit: {
+    type: 'function',
+    default: _.constant(null),
+    allowsPresets: true
+  },
+  incrementVersion: {
+    type: 'function',
+    default: 'semver',
+    allowsPresets: true
+  },
+  getGitReferenceFromVersion: {
+    type: 'function',
+    default: _.identity,
+    allowsPresets: true
+  },
+  addEntryToChangelog: {
+    type: 'function',
+    default: 'prepend',
+    allowsPresets: true
+  },
+  updateVersion: {
+    type: 'function',
+    default: 'npm',
+    allowsPresets: true
+  },
+  template: {
+    type: 'string',
+    default: [
+      '## {{version}} - {{moment date "Y-MM-DD"}}',
+      '',
+      '{{#each commits}}',
+      '{{#if this.subject.title}}',
+      '- {{capitalize this.subject.title}}',
+      '{{else}}',
+      '- {{capitalize this.subject}}',
+      '{{/if}}',
+      '{{/each}}'
+    ].join('\n')
+  }
+};
+
+/**
+ * @summary Check if a property is a preset property
+ * @function
+ * @private
+ *
+ * @param {*} value - property value
+ * @returns {Boolean} whether the value is a preset property
+ *
+ * @example
+ * if (configuration.isPresetProperty('foo')) {
+ *   console.log('This is a preset property');
+ * }
+ */
+exports.isPresetProperty = (value) => {
+  return _.some([
+    _.isString(value),
+    _.isPlainObject(value) && _.isString(value.preset)
+  ]);
+};
+
+/**
+ * @summary Parse a preset definition
+ * @function
+ * @private
+ *
+ * @param {(String|Object)} value - preset value
+ * @returns {Object} preset definition
+ *
+ * @example
+ * const definition = configuration.parsePresetDefinition({
+ *   preset: 'foo',
+ *   myOption: 1
+ * });
+ *
+ * console.log(definition.name);
+ * console.log(definition.options.myOption);
+ */
+exports.parsePresetDefinition = (value) => {
+  if (_.isString(value)) {
+    return {
+      name: value,
+      options: {}
+    };
+  }
+
+  return {
+    name: value.preset,
+    options: _.omit(value, 'preset')
+  };
+};
+
+/**
+ * @summary Get a property parsed value
+ * @function
+ * @private
+ *
+ * @param {String} propertyName - property name
+ * @param {Object} propertyDescription - property description
+ * @param {*} [propertyDescription.default] - default value
+ * @param {Object} data - configuration data
+ * @returns {*} value
+ *
+ * @example
+ * const value = configuration.getPropertyParsedValue('hello', {
+ *   type: 'string',
+ *   default: 'foo'
+ * }, {
+ *   hello: 'bar'
+ * });
+ */
+exports.getPropertyParsedValue = (propertyName, propertyDescription, data) => {
+  const currentValue = _.get(data, propertyName);
+
+  if (_.isUndefined(currentValue) || _.isNull(currentValue)) {
+    return propertyDescription.default;
+  }
+
+  return currentValue;
+};
+
+/**
+ * @summary Determine if a property value is valid
+ * @function
+ * @private
+ *
+ * @param {String} propertyDescription - property description
+ * @param {String} propertyDescription.type - property type
+ * @param {*} value - value
+ * @returns {Boolean} whether the value type is valid
+ *
+ * @example
+ * if (configuration.isPropertyValueValid({
+ *   type: 'string'
+ * }, 'foo')) {
+ *   console.log('Foo is valid!');
+ * }
+ */
+exports.isPropertyValueValid = (propertyDescription, value) => {
+  return typeof value === propertyDescription.type;
+};
+
+/**
+ * @summary Parse a preset value
+ * @function
+ * @private
+ *
+ * @param {Object} presetsHash - presets hash
+ * @param {String} propertyName - property name
+ * @param {(String|Object)} value - preset value
+ * @returns {Function} preset function
+ *
+ * @example
+ * const preset = configuration.parsePreset({
+ *   foo: {
+ *     hello: (options, name) => {
+ *       return `Hello ${name}`;
+ *     }
+ *   }
+ * }, 'foo', 'hello');
+ *
+ * preset('Juan');
+ */
+exports.parsePreset = (presetsHash, propertyName, value) => {
+  const propertyPresets = _.get(presetsHash, propertyName, {});
+  const presetDefinition = exports.parsePresetDefinition(value);
+  const presetFunction = _.get(propertyPresets, presetDefinition.name);
+
+  if (!presetFunction) {
+    throw new Error(`Invalid preset: ${propertyName} -> ${presetDefinition.name}`);
+  }
+
+  return _.partial(presetFunction, presetDefinition.options);
+};
+
+/**
+ * @summary Parse a configuration file object
+ * @function
+ * @public
+ *
+ * @param {Object} data - configuration data
+ * @returns {Object} parsed configuration
+ *
+ * @example
+ * const options = configuration.parse({
+ *   changelogFile: 'Foo.md',
+ *   editVersion: false
+ * });
+ */
+exports.parse = (data) => {
+  return _.mapValues(DEFAULTS, (propertyDescription, propertyName) => {
+    const value = exports.getPropertyParsedValue(propertyName, propertyDescription, data);
+
+    if (exports.isPresetProperty(value) && propertyDescription.allowsPresets) {
+      return exports.parsePreset(presets, propertyName, value);
+    }
+
+    if (!exports.isPropertyValueValid(propertyDescription, value)) {
+      throw new Error([
+        `Invalid option value: ${value}.`,
+        `The \`${propertyName}\` option expects a ${propertyDescription.type},`,
+        `but instead got a ${typeof value}.`
+      ].join(' '));
+    }
+
+    return value;
+  });
+};
+
+/**
+ * @summary Load a configuration file
+ * @function
+ * @public
+ *
+ * @param {String} file - file path
+ * @returns {Object} configuration
+ *
+ * @example
+ * const config = configuration.load('versionist.conf.js');
+ * console.log(config);
+ */
+exports.load = (file) => {
+  try {
+    return require(file);
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      throw new Error(`Can't find ${file}`);
+    } else if (error instanceof SyntaxError) {
+      throw new Error(`Syntax error in configuration file: ${file}`);
+    }
+
+    throw error;
+  }
+};

--- a/tests/cli-configuration.spec.js
+++ b/tests/cli-configuration.spec.js
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+const m = require('mochainon');
+const configuration = require('../lib/cli/configuration');
+
+describe('CLI Configuration', function() {
+
+  describe('.isPresetProperty()', function() {
+
+    it('should return true if property is a string', function() {
+      const property = 'foo';
+      m.chai.expect(configuration.isPresetProperty(property)).to.be.true;
+    });
+
+    it('should return false if property is a number', function() {
+      const property = 1;
+      m.chai.expect(configuration.isPresetProperty(property)).to.be.false;
+    });
+
+    it('should return false if property is a function', function() {
+      const property = _.noop;
+      m.chai.expect(configuration.isPresetProperty(property)).to.be.false;
+    });
+
+    it('should return false if property is an empty object', function() {
+      const property = {};
+      m.chai.expect(configuration.isPresetProperty(property)).to.be.false;
+    });
+
+    it('should return true if property is an object containing a preset string value', function() {
+      const property = {
+        preset: 'foo'
+      };
+
+      m.chai.expect(configuration.isPresetProperty(property)).to.be.true;
+    });
+
+    it('should return true if property is an object containing a preset string value and other keys', function() {
+      const property = {
+        preset: 'foo',
+        hello: 'world',
+        foo: 123
+      };
+
+      m.chai.expect(configuration.isPresetProperty(property)).to.be.true;
+    });
+
+    it('should return false if property is an object containing a preset number value', function() {
+      const property = {
+        preset: 1
+      };
+
+      m.chai.expect(configuration.isPresetProperty(property)).to.be.false;
+    });
+
+    it('should return false if property is an object containing a preset function value', function() {
+      const property = {
+        preset: _.noop
+      };
+
+      m.chai.expect(configuration.isPresetProperty(property)).to.be.false;
+    });
+
+  });
+
+  describe('.parsePresetDefinition()', function() {
+
+    it('should parse a string preset', function() {
+      const preset = 'foo';
+      m.chai.expect(configuration.parsePresetDefinition(preset)).to.deep.equal({
+        name: 'foo',
+        options: {}
+      });
+    });
+
+    it('should parse an object preset without options', function() {
+      m.chai.expect(configuration.parsePresetDefinition({
+        preset: 'foo'
+      })).to.deep.equal({
+        name: 'foo',
+        options: {}
+      });
+    });
+
+    it('should parse an object preset with options', function() {
+      m.chai.expect(configuration.parsePresetDefinition({
+        preset: 'foo',
+        option: 1,
+        hello: 'world'
+      })).to.deep.equal({
+        name: 'foo',
+        options: {
+          option: 1,
+          hello: 'world'
+        }
+      });
+    });
+
+  });
+
+  describe('.getPropertyParsedValue()', function() {
+
+    describe('given a string property', function() {
+
+      it('should return the default value if undeclared', function() {
+        const value = configuration.getPropertyParsedValue('hello', {
+          type: 'string',
+          default: 'foo'
+        }, {});
+
+        m.chai.expect(value).to.equal('foo');
+      });
+
+      it('should return the default value if undefined', function() {
+        const value = configuration.getPropertyParsedValue('hello', {
+          type: 'string',
+          default: 'foo'
+        }, {
+          hello: undefined
+        });
+
+        m.chai.expect(value).to.equal('foo');
+      });
+
+      it('should return the default value if null', function() {
+        const value = configuration.getPropertyParsedValue('hello', {
+          type: 'string',
+          default: 'foo'
+        }, {
+          hello: null
+        });
+
+        m.chai.expect(value).to.equal('foo');
+      });
+
+    });
+
+    describe('given a boolean property', function() {
+
+      it('should not return the default value if false', function() {
+        const value = configuration.getPropertyParsedValue('hello', {
+          type: 'boolean',
+          default: true
+        }, {
+          hello: false
+        });
+
+        m.chai.expect(value).to.be.false;
+      });
+
+      it('should return the default value if undefined', function() {
+        const value = configuration.getPropertyParsedValue('hello', {
+          type: 'boolean',
+          default: true
+        }, {
+          hello: undefined
+        });
+
+        m.chai.expect(value).to.be.true;
+      });
+
+      it('should return the default value if null', function() {
+        const value = configuration.getPropertyParsedValue('hello', {
+          type: 'boolean',
+          default: true
+        }, {
+          hello: null
+        });
+
+        m.chai.expect(value).to.be.true;
+      });
+
+    });
+
+    describe('given a number property', function() {
+
+      it('should not return the default value if 0', function() {
+        const value = configuration.getPropertyParsedValue('hello', {
+          type: 'number',
+          default: 1
+        }, {
+          hello: 0
+        });
+
+        m.chai.expect(value).to.equal(0);
+      });
+
+    });
+
+  });
+
+  describe('.isPropertyValueValid()', function() {
+
+    it('should return true if the property value type is valid', function() {
+      m.chai.expect(configuration.isPropertyValueValid({
+        type: 'string'
+      }, 'foo')).to.be.true;
+
+      m.chai.expect(configuration.isPropertyValueValid({
+        type: 'number'
+      }, 1)).to.be.true;
+
+      m.chai.expect(configuration.isPropertyValueValid({
+        type: 'function'
+      }, _.noop)).to.be.true;
+    });
+
+    it('should return false if the property value type is not valid', function() {
+      m.chai.expect(configuration.isPropertyValueValid({
+        type: 'string'
+      }, 1)).to.be.false;
+
+      m.chai.expect(configuration.isPropertyValueValid({
+        type: 'number'
+      }, 'foo')).to.be.false;
+
+      m.chai.expect(configuration.isPropertyValueValid({
+        type: 'function'
+      }, {})).to.be.false;
+    });
+
+  });
+
+  describe('.parsePreset()', function() {
+
+    it('should throw if the preset was not found', function() {
+      m.chai.expect(() => {
+        configuration.parsePreset({
+          foo: {}
+        }, 'foo', 'hello');
+      }).to.throw('Invalid preset: foo -> hello');
+    });
+
+    it('should partially apply the options to the preset', function() {
+      const preset = configuration.parsePreset({
+        foo: {
+          hello: (options) => {
+            return options.foo;
+          }
+        }
+      }, 'foo', {
+        preset: 'hello',
+        foo: 'bar'
+      });
+
+      m.chai.expect(preset()).to.equal('bar');
+    });
+
+  });
+
+});


### PR DESCRIPTION
The CLI configuration file loading/parsing logic is moved to
`lib/cli/configuration.js`. Moving this logic to a different file allows
this functionality to be unit-tested more easily.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>