### PR TITLE
fix: ensure a specified config file is parsed correctly

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -56,7 +56,7 @@ const argv = yargs
   .config('config', 'configuration file', (file) => {
     try {
       return {
-        config: configuration.parse(configuration.load(file))
+        configuration: configuration.parse(configuration.load(file))
       };
     } catch (error) {
       showErrorAndQuit(error);
@@ -99,19 +99,19 @@ const argv = yargs
 async.waterfall([
 
   (callback) => {
-    argv.config.getChangelogDocumentedVersions(argv.config.changelogFile, callback);
+    argv.configuration.getChangelogDocumentedVersions(argv.configuration.changelogFile, callback);
   },
 
   (documentedVersions, callback) => {
     const versions = _.attempt(() => {
       if (_.isEmpty(documentedVersions)) {
-        return [ argv.config.defaultInitialVersion ];
+        return [ argv.configuration.defaultInitialVersion ];
       }
 
       return documentedVersions;
     });
 
-    const gitReference = argv.config.getGitReferenceFromVersion(semver.getGreaterVersion(versions));
+    const gitReference = argv.configuration.getGitReferenceFromVersion(semver.getGreaterVersion(versions));
     return referenceExists(gitReference, (error, exists) => {
       if (error) {
         return callback(error);
@@ -130,12 +130,12 @@ async.waterfall([
   },
 
   (documentedVersions, startReference, callback) => {
-    versionist.readCommitHistory(path.join(argv.config.path, argv.config.gitDirectory), {
+    versionist.readCommitHistory(path.join(argv.configuration.path, argv.configuration.gitDirectory), {
       startReference: startReference,
       endReference: 'HEAD',
-      subjectParser: argv.config.subjectParser,
-      bodyParser: argv.config.bodyParser,
-      parseFooterTags: argv.config.parseFooterTags
+      subjectParser: argv.configuration.subjectParser,
+      bodyParser: argv.configuration.bodyParser,
+      parseFooterTags: argv.configuration.parseFooterTags
     }, (error, history) => {
       return callback(error, documentedVersions, history);
     });
@@ -143,9 +143,9 @@ async.waterfall([
 
   (documentedVersions, history, callback) => {
     const version = versionist.calculateNextVersion(history, {
-      getIncrementLevelFromCommit: argv.config.getIncrementLevelFromCommit,
+      getIncrementLevelFromCommit: argv.configuration.getIncrementLevelFromCommit,
       currentVersion: argv.current || semver.getGreaterVersion(documentedVersions),
-      incrementVersion: argv.config.incrementVersion
+      incrementVersion: argv.configuration.incrementVersion
     });
 
     if (_.includes(documentedVersions, version)) {
@@ -154,14 +154,14 @@ async.waterfall([
     }
 
     const entry = versionist.generateChangelog(history, {
-      template: argv.config.template,
-      includeCommitWhen: argv.config.includeCommitWhen,
-      transformTemplateData: argv.config.transformTemplateData,
+      template: argv.configuration.template,
+      includeCommitWhen: argv.configuration.includeCommitWhen,
+      transformTemplateData: argv.configuration.transformTemplateData,
       version: version
     });
 
-    if (argv.config.editChangelog) {
-      argv.config.addEntryToChangelog(argv.config.changelogFile, entry, (error) => {
+    if (argv.configuration.editChangelog) {
+      argv.configuration.addEntryToChangelog(argv.configuration.changelogFile, entry, (error) => {
         return callback(error, version);
       });
     } else {
@@ -171,8 +171,8 @@ async.waterfall([
   },
 
   (version, callback) => {
-    if (argv.config.editVersion) {
-      argv.config.updateVersion(process.cwd(), version, callback);
+    if (argv.configuration.editVersion) {
+      argv.configuration.updateVersion(process.cwd(), version, callback);
     } else {
       return callback();
     }

--- a/tests/cli/cases/config-file.js
+++ b/tests/cli/cases/config-file.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const shelljs = require('shelljs');
+const utils = require('../utils');
+const TEST_DIRECTORY = utils.getTestTemporalPathFromFilename(__filename);
+
+shelljs.rm('-rf', TEST_DIRECTORY);
+shelljs.mkdir('-p', TEST_DIRECTORY);
+shelljs.cd(TEST_DIRECTORY);
+
+utils.createVersionistConfiguration([
+  '\'use strict\';',
+  'module.exports = {',
+  '  subjectParser: \'angular\',',
+  '  editVersion: false,',
+  '  addEntryToChangelog: \'prepend\',',
+  '  includeCommitWhen: (commit) => {',
+  '    return commit.footer[\'Changelog-Entry\'];',
+  '  },',
+  '  getIncrementLevelFromCommit: (commit) => {',
+  '    return commit.footer[\'Change-Type\'];',
+  '  },',
+  '  template: [',
+  '    \'## {{version}}\',',
+  '    \'\',',
+  '    \'{{#each commits}}\',',
+  '    \'{{#with footer}}\',',
+  '    \'- {{capitalize Changelog-Entry}}\',',
+  '    \'{{/with}}\',',
+  '    \'{{/each}}\'',
+  '  ].join(\'\\n\')',
+  '};',
+  ''
+].join('\n'));
+
+shelljs.exec('git init');
+
+utils.createCommit('feat: implement x', {
+  'Changelog-Entry': 'Implement x',
+  'Change-Type': 'minor'
+});
+
+utils.createCommit('fix: fix y', {
+  'Changelog-Entry': 'Fix y',
+  'Change-Type': 'patch'
+});
+
+utils.createCommit('fix: fix z', {
+  'Changelog-Entry': 'Fix z',
+  'Change-Type': 'patch'
+});
+
+// Call Versionist with the configuration file
+utils.callVersionist('versionist.conf.js');
+
+m.chai.expect(shelljs.cat('CHANGELOG.md').stdout).to.deep.equal([
+  '## 0.1.0',
+  '',
+  '- Fix z',
+  '- Fix y',
+  '- Implement x',
+  ''
+].join('\n'));

--- a/tests/cli/utils.js
+++ b/tests/cli/utils.js
@@ -44,7 +44,11 @@ exports.createVersionistConfiguration = (configuration) => {
   shelljs.echo(configuration).to('versionist.conf.js');
 };
 
-exports.callVersionist = () => {
+exports.callVersionist = (configFile) => {
   const cliPath = path.join(__dirname, '..', '..', 'bin', 'cli.js');
-  shelljs.exec(`node ${cliPath}`);
+  let configString = '';
+  if (configFile) {
+    configString += ` --config ${configFile}`;
+  }
+  shelljs.exec(`node ${cliPath}${configString}`);
 };


### PR DESCRIPTION
Due to the way `yargs` operates, a named option cannot be used
as an object to pass back a new set of options (in this case
the loaded configuration), as the key on `argv` essentially already
exists.

To mitigate this, the returned object is renamed `configuration` and
this is used in place of `config` for all further operations.

Connects to #46.

Change-Type: minor
Changelog-Entry: Ensure a specified config file is parsed correctly.