### PR TITLE
Add a `versionist` script to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "test": "npm run lint && mocha tests -R spec && node tests/cli/run",
-    "lint": "eslint lib tests bin"
+    "lint": "eslint lib/ tests/ bin/",
+    "versionist": "./bin/cli.js"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
So that versionist can be run on itself, without needing to be installed
globally.

Fixes #64

Change-Type: minor